### PR TITLE
[APP-2051] Update Column#initialize to pass on **kwargs (rails 6.1 compatibility)

### DIFF
--- a/lib/odbc_adapter/column.rb
+++ b/lib/odbc_adapter/column.rb
@@ -5,8 +5,8 @@ module ODBCAdapter
     # Add the native_type accessor to allow the native DBMS to report back what
     # it uses to represent the column internally.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, native_type = nil)
-      super(name, default, sql_type_metadata, null, table_name)
+    def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, native_type = nil, **kwargs)
+      super(name, default, sql_type_metadata, null, table_name, kwargs)
       @native_type = native_type
     end
   end


### PR DESCRIPTION
Source
======

https://springbuk-glass.atlassian.net/browse/APP-2051

Problem
=======

The linked story is the first implementation of snowflake in the main Springbuk app. Springbuk is on 6.1, and ActiveRecord 6.1 is passing ** to allow kwargs through.

In our use case, there's nothing actually being passed here, but we should just keep passing them along in the call chain.

Solution
========

Adds `**kwargs` to initialize signature and pass along to super.

Testing/QA Notes
================

Tested locally in springbuk (6.1.4) and edison (6.0.3).

Post Merge Notes
================

n/a