### PR TITLE
Limit DB info to current schema

### DIFF
--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -15,8 +15,9 @@ module ODBCAdapter
       stmt.drop
 
       db_regex = /^#{current_database}$/i
+      schema_regex = /^#{current_schema}$/i
       result.each_with_object([]) do |row, table_names|
-        next unless row[0] =~ db_regex
+        next unless row[0] =~ db_regex && row[1] =~ schema_regex
         schema_name, table_name, table_type = row[1..3]
         next if respond_to?(:table_filtered?) && table_filtered?(schema_name, table_type)
         table_names << format_case(table_name)
@@ -39,8 +40,9 @@ module ODBCAdapter
       unique     = nil
 
       db_regex = /^#{current_database}$/i
+      schema_regex = /^#{current_schema}$/i
       result.each_with_object([]).with_index do |(row, indices), row_idx|
-        next unless row[0] =~ db_regex
+        next unless row[0] =~ db_regex && row[1] =~ schema_regex
         # Skip table statistics
         next if row[6].zero? # SQLStatistics: TYPE
 
@@ -68,8 +70,9 @@ module ODBCAdapter
       stmt.drop
 
       db_regex = /^#{current_database}$/i
+      schema_regex = /^#{current_schema}$/i
       result.each_with_object([]) do |col, cols|
-        next unless col[0] =~ db_regex
+        next unless col[0] =~ db_regex && row[1] =~ schema_regex
         col_name        = col[3]  # SQLColumns: COLUMN_NAME
         col_default     = col[12] # SQLColumns: COLUMN_DEF
         col_sql_type    = col[4]  # SQLColumns: DATA_TYPE
@@ -102,7 +105,8 @@ module ODBCAdapter
       stmt.drop unless stmt.nil?
 
       db_regex = /^#{current_database}$/i
-      result.reduce(nil) { |pkey, key| key[0] =~ db_regex ? key[3] : pkey }
+      schema_regex = /^#{current_schema}$/i
+      result.reduce(nil) { |pkey, key| (key[0] =~ db_regex && key[1] =~ schema_regex) ? key[3] : pkey }
     end
 
     def foreign_keys(table_name)
@@ -111,8 +115,9 @@ module ODBCAdapter
       stmt.drop unless stmt.nil?
 
       db_regex = /^#{current_database}$/i
+      schema_regex = /^#{current_schema}$/i
       result.map do |key|
-        next unless key[0] =~ db_regex
+        next unless key[0] =~ db_regex && key[1] =~ schema_regex
         fk_from_table      = key[2]  # PKTABLE_NAME
         fk_to_table        = key[6]  # FKTABLE_NAME
 
@@ -137,6 +142,10 @@ module ODBCAdapter
 
     def current_database
       database_metadata.database_name.strip
+    end
+
+    def current_schema
+      @config[:driver].attrs['schema']
     end
   end
 end


### PR DESCRIPTION
Problem: The SchemaStatements methods get tables from all schemas without identifying which schema each came from.

Change: limit the SchemaStatements methods to return objects in the current schema only.