### PR TITLE
[MOJ-95] Corrections to the columns function

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -139,8 +139,8 @@ module ActiveRecord
       # Build a new column object from the given options. Effectively the same
       # as super except that it also passes in the native type.
       # rubocop:disable Metrics/ParameterLists
-      def new_column(name, default, sql_type_metadata, null, table_name, native_type = nil)
-        ::ODBCAdapter::Column.new(name, default, sql_type_metadata, null, table_name, native_type)
+      def new_column(name, default, sql_type_metadata, null, native_type = nil)
+        ::ODBCAdapter::Column.new(name, default, sql_type_metadata, null, native_type)
       end
 
       protected

--- a/lib/odbc_adapter/column.rb
+++ b/lib/odbc_adapter/column.rb
@@ -5,8 +5,8 @@ module ODBCAdapter
     # Add the native_type accessor to allow the native DBMS to report back what
     # it uses to represent the column internally.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, native_type = nil, **kwargs)
-      super(name, default, sql_type_metadata, null, table_name, kwargs)
+    def initialize(name, default, sql_type_metadata = nil, null = true, native_type = nil, **kwargs)
+      super(name, default, sql_type_metadata, null, **kwargs)
       @native_type = native_type
     end
   end

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -94,7 +94,7 @@ module ODBCAdapter
         end
         sql_type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(**args)
 
-        cols << new_column(format_case(col_name), col_default, sql_type_metadata, col_nullable, table_name, col_native_type)
+        cols << new_column(format_case(col_name), col_default, sql_type_metadata, col_nullable, col_native_type)
       end
     end
 

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -83,12 +83,19 @@ module ODBCAdapter
         # SQLColumns: IS_NULLABLE, SQLColumns: NULLABLE
         col_nullable = nullability(col_name, col[17], col[10])
 
-        args = { sql_type: col_sql_type, type: col_sql_type, limit: col_limit }
-        args[:sql_type] = 'boolean' if col_native_type == self.class::BOOLEAN_TYPE
-        args[:sql_type] = 'json' if col_native_type == self.class::VARIANT_TYPE || col_native_type == self.class::JSON_TYPE
-        args[:sql_type] = 'date' if col_native_type == self.class::DATE_TYPE
+        # This section has been customized for Snowflake and will not work in general.
+        args = { sql_type: col_native_type, type: col_native_type, limit: col_limit }
+        args[:type] = 'boolean' if col_native_type == "BOOLEAN"  # self.class::BOOLEAN_TYPE
+        args[:type] = 'json' if col_native_type == "VARIANT" || col_native_type == "JSON"
+        args[:type] = 'date' if col_native_type == "DATE"
+        args[:type] = 'string' if col_native_type == "VARCHAR"
+        args[:type] = 'datetime' if col_native_type == "TIMESTAMP"
+        args[:type] = 'time' if col_native_type == "TIME"
+        args[:type] = 'binary' if col_native_type == "BINARY"
+        args[:type] = 'float' if col_native_type == "DOUBLE"
 
         if [ODBC::SQL_DECIMAL, ODBC::SQL_NUMERIC].include?(col_sql_type)
+          args[:type] = col_scale == 0 ? 'integer' : 'decimal'
           args[:scale]     = col_scale || 0
           args[:precision] = col_limit
         end

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -106,7 +106,7 @@ module ODBCAdapter
 
       db_regex = name_regex(current_database)
       schema_regex = name_regex(current_schema)
-      result.reduce(nil) { |pkey, key| (key[0] =~ db_regex && key[1] =~ schema_regex) ? key[3] : pkey }
+      result.reduce(nil) { |pkey, key| (key[0] =~ db_regex && key[1] =~ schema_regex) ? format_case(key[3]) : pkey }
     end
 
     def foreign_keys(table_name)


### PR DESCRIPTION
With Ruby 3 the columns function started failing. The argument list to ActiveRecord::ConnectionAdapters::Column.initialize changed to remove the table name. Ruby 2.6 did not complain about the optional argument mismatch.

Also:
Identified the primary_key function was returning the column name as uppercase. Corrected that issue.

Identified the data types returned by columns were not very usable and generally resulted in string type. Created a Snowflake table with all of the snowflake data types and verified they were mapped (except object, array and geographic).