### PR TITLE
[APP-2295] Update signature of translate_exception for ruby 3

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -182,7 +182,7 @@ module ActiveRecord
 
       # Translate an exception from the native DBMS to something usable by
       # ActiveRecord.
-      def translate_exception(exception, message)
+      def translate_exception(exception, message:, sql:, binds:)
         error_number = exception.message[/^\d+/].to_i
 
         if error_number == ERR_DUPLICATE_KEY_VALUE


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/APP-2295

## Problem

error in `odbc_adapter/lib/active_record/connection_adapters/odbc_adapter.rb:200 in translate_exception`

## Solution

Update method signature to match what is used in ruby 3

## Testing/QA Notes

TBD

## Testing/QA Parties

TBD

##  Post Merge Notes

TBD
