### PR TITLE
MOJ-98 Correct column default values

### DIFF
--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -101,6 +101,13 @@ module ODBCAdapter
         end
         sql_type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(**args)
 
+        # The @connection.columns function returns empty strings for column defaults.
+        # Even when the column has a default value. This is a call to the ODBC layer
+        # with only enough Ruby to make the call happen. Replacing the empty string
+        # with nil permits Rails to set the current datetime for created_at and
+        # updated_at on model creates and updates.
+        col_default = nil if col_default == ""
+
         cols << new_column(format_case(col_name), col_default, sql_type_metadata, col_nullable, col_native_type)
       end
     end


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/MOJ-98

## Problem

Rails is not setting default values for created_at and updated_at columns.

## Solution

The SchemaStatements.columns functions returns an empty string for the default value on all columns. Rails is detecting a default value for created_at and updated_at and is not setting the column. Changing the function to replace the empty string with nil corrects the problem.

A problem remains.. ODBC driver is not returning the default value for columns. We could replace the ODBC columns call with a query of information_schema.columns if there is a need for the default values.