### PR TITLE
[MOJ-97] Better type handling for Snowflake

### DIFF
--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -79,6 +79,8 @@ module ODBCAdapter
           value = row[col_index]
 
           new_value = case
+                      when value.nil?
+                        nil
                       when ["CHAR", "VARCHAR", "LONGVARCHAR"].include?(column_type)
                         # Do nothing, because the data defaults to strings
                         # This also covers null values, as they are VARCHARs of length 0

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -1,5 +1,3 @@
-require "json"
-
 module ODBCAdapter
   module DatabaseStatements
     # ODBC constants missing from Christian Werner's Ruby ODBC driver
@@ -26,7 +24,6 @@ module ODBCAdapter
 
         columns = stmt.columns
         values  = stmt.to_a
-        # binding.pry
         stmt.drop
 
         values = dbms_type_cast(columns.values, values)
@@ -78,16 +75,8 @@ module ODBCAdapter
       columns.map.with_index do |column, col_index|
         column_type = @connection.types(column.type).first[0]
 
-        # binding.pry
-        # @connection.types(3).columns.keys
-
-        # pp column
-        # pp "Column type: #{column.type} | #{@connection.types(column.type).first}"
-
         rows.each_with_index do |row, row_index|
           value = row[col_index]
-
-          binding.pry
 
           new_value = case
                       when ["CHAR", "VARCHAR", "LONGVARCHAR"].include?(column_type)
@@ -124,16 +113,8 @@ module ODBCAdapter
                         raise "Unknown column type: #{column_type}"
                       end
 
-          pp "Column type: #{column_type}"
-          pp "Value: #{value}(#{value.class})"
-          pp "New Value: #{new_value}(#{new_value.class})"
-          # binding.pry
-
           rows[row_index][col_index] = new_value
-          # .cast(row[cidx])
         end
-
-        # @connection.types.to_a[3]
       end
     end
 


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/MOJ-97

## Problem

We're only ever returning `String`s from `Snowflake`

## Solution

Add correct type hanlding.

## Testing/QA Notes

As there are no tests currently for `snowflake`, the best thing to test this is to load it up locally, run some queries, and check the `ruby` types of the returned results.

Corresponding PRs:
springbuk/springbuk#6041
springbuk/edison#723
springbuk/data_management#2424


##  Post Merge Notes

After this PR lands, we'll as need to update the `Gemfile.lock` in the other PRs to point to the newest version.