### PR TITLE
Claims page was broken, discovered the bug is in the ODBC Adapter.

### DIFF
--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -107,10 +107,12 @@ module ODBCAdapter
                         # if here, but there's not a good way to tell what the type is
                         # without trying to parse the value as JSON as see if it works
                         # JSON.parse(value)
+                        raise "Unhandled column type: #{column_type}"
                       when ["BINARY", "VARBINARY"].include?(column_type)
                         # These don't actually ever seem to return, even though they are
                         # defined in the ODBC driver, but I left them in here just in case
                         # so that future us can see what they should be
+                        raise "Unhandled column type: #{column_type}"
                       else
                         raise "Unknown column type: #{column_type}"
                       end
@@ -118,6 +120,7 @@ module ODBCAdapter
           rows[row_index][col_index] = new_value
         end
       end
+      rows
     end
 
     def bind_params(binds, sql)


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/MOJ-121

## Problem

Claims page was broken upon using the new odbc adapter in master

## Solution

dbms_type_cast needs to return rows at the end. Also added code to raise exceptions, since currently these circumstances shouldn't be encountered and if that changes spontaneously (such as through an snowflake odbc driver update) we want to know rather than silently have nil values.

## Testing/QA Notes

As there are no tests currently for `snowflake`, the best thing to test this is to load it up locally, run some queries, and check the `ruby` types of the returned results.

##  Post Merge Notes

This PR will require additional PRs be merged into springbuk, edison, and data management