### PR TITLE
MOJ-137 Fix can't quote errors

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -145,39 +145,18 @@ module ActiveRecord
 
       protected
 
-      # Build the type map for ActiveRecord
-      # Here, ODBC and ODBC_UTF8 constants are interchangeable
+      #Snowflake ODBC Adapter specific
       def initialize_type_map(map)
-        map.register_type 'boolean',              Type::Boolean.new
-        map.register_type 'json',                 Type::Json.new
-        map.register_type ODBC::SQL_CHAR,         Type::String.new
-        map.register_type ODBC::SQL_LONGVARCHAR,  Type::Text.new
-        map.register_type ODBC::SQL_TINYINT,      Type::Integer.new(limit: 4)
-        map.register_type ODBC::SQL_SMALLINT,     Type::Integer.new(limit: 8)
-        map.register_type ODBC::SQL_INTEGER,      Type::Integer.new(limit: 16)
-        map.register_type ODBC::SQL_BIGINT,       Type::BigInteger.new(limit: 32)
-        map.register_type ODBC::SQL_REAL,         Type::Float.new(limit: 24)
-        map.register_type ODBC::SQL_FLOAT,        Type::Float.new
-        map.register_type ODBC::SQL_DOUBLE,       Type::Float.new(limit: 53)
-        map.register_type ODBC::SQL_DECIMAL,      Type::Float.new
-        map.register_type ODBC::SQL_NUMERIC,      Type::Integer.new
-        map.register_type ODBC::SQL_BINARY,       Type::Binary.new
-        map.register_type ODBC::SQL_DATE,         Type::Date.new
-        map.register_type ODBC::SQL_DATETIME,     Type::DateTime.new
-        map.register_type ODBC::SQL_TIME,         Type::Time.new
-        map.register_type ODBC::SQL_TIMESTAMP,    Type::DateTime.new
-        map.register_type ODBC::SQL_GUID,         Type::String.new
-
-        alias_type map, ODBC::SQL_BIT,            'boolean'
-        alias_type map, ODBC::SQL_VARCHAR,        ODBC::SQL_CHAR
-        alias_type map, ODBC::SQL_WCHAR,          ODBC::SQL_CHAR
-        alias_type map, ODBC::SQL_WVARCHAR,       ODBC::SQL_CHAR
-        alias_type map, ODBC::SQL_WLONGVARCHAR,   ODBC::SQL_LONGVARCHAR
-        alias_type map, ODBC::SQL_VARBINARY,      ODBC::SQL_BINARY
-        alias_type map, ODBC::SQL_LONGVARBINARY,  ODBC::SQL_BINARY
-        alias_type map, ODBC::SQL_TYPE_DATE,      ODBC::SQL_DATE
-        alias_type map, ODBC::SQL_TYPE_TIME,      ODBC::SQL_TIME
-        alias_type map, ODBC::SQL_TYPE_TIMESTAMP, ODBC::SQL_TIMESTAMP
+        map.register_type :boolean,               Type::Boolean.new
+        map.register_type :json,                  Type::Json.new
+        map.register_type :date,                  Type::Date.new
+        map.register_type :string,                Type::String.new
+        map.register_type :datetime,              Type::DateTime.new
+        map.register_type :time,                  Type::Time.new
+        map.register_type :binary,                Type::Binary.new
+        map.register_type :float,                 Type::Float.new
+        map.register_type :integer,               Type::Integer.new
+        map.register_type :decimal,               Type::Decimal.new
       end
 
       # Translate an exception from the native DBMS to something usable by

--- a/lib/odbc_adapter/quoting.rb
+++ b/lib/odbc_adapter/quoting.rb
@@ -38,5 +38,9 @@ module ODBCAdapter
         value.strftime('%Y-%m-%d') # Date
       end
     end
+
+    def lookup_cast_type_from_column(column) # :nodoc:
+      type_map.lookup(column.type)
+    end
   end
 end

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -85,17 +85,17 @@ module ODBCAdapter
 
         # This section has been customized for Snowflake and will not work in general.
         args = { sql_type: col_native_type, type: col_native_type, limit: col_limit }
-        args[:type] = 'boolean' if col_native_type == "BOOLEAN"  # self.class::BOOLEAN_TYPE
-        args[:type] = 'json' if col_native_type == "VARIANT" || col_native_type == "JSON"
-        args[:type] = 'date' if col_native_type == "DATE"
-        args[:type] = 'string' if col_native_type == "VARCHAR"
-        args[:type] = 'datetime' if col_native_type == "TIMESTAMP"
-        args[:type] = 'time' if col_native_type == "TIME"
-        args[:type] = 'binary' if col_native_type == "BINARY"
-        args[:type] = 'float' if col_native_type == "DOUBLE"
+        args[:type] = :boolean if col_native_type == "BOOLEAN"  # self.class::BOOLEAN_TYPE
+        args[:type] = :json if col_native_type == "VARIANT" || col_native_type == "JSON"
+        args[:type] = :date if col_native_type == "DATE"
+        args[:type] = :string if col_native_type == "VARCHAR"
+        args[:type] = :datetime if col_native_type == "TIMESTAMP"
+        args[:type] = :time if col_native_type == "TIME"
+        args[:type] = :binary if col_native_type == "BINARY"
+        args[:type] = :float if col_native_type == "DOUBLE"
 
         if [ODBC::SQL_DECIMAL, ODBC::SQL_NUMERIC].include?(col_sql_type)
-          args[:type] = col_scale == 0 ? 'integer' : 'decimal'
+          args[:type] = col_scale == 0 ? :integer : :decimal
           args[:scale]     = col_scale || 0
           args[:precision] = col_limit
         end


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/MOJ-137

## Problem

Trying to update records using hashes or arrays (possibly other types) was throwing a can't quote error

## Solution

Can't quote error is caused by active_record not knowing what types columns are

Updated infrastructure needed for models to know what types their attributes are so it will properly handle type casting automatically.
This also removes the necessity of specifying json attributes on models.
The only reason that dbms_type_cast is still useful is for when we're executing raw queries instead of using the object model.

## Testing/QA Notes

Pushing to SB3 Springbuk & Edison. Should have working claims pages and other parts of the application that rely on edison. Can test locally by running an edison rails console locally and running
```
Feedback.create(user_id: 2101, account_group_id: 1785, feedbackable_id: 441, feedbackable_type: "Rule", feedback: {this_is: "A hash", previously: "this would've given a can't quote error"})
```

The statement will likely still fail at the moment due to an unrelated issue (the primary key isn't properly getting it's sequence), but you'll see the insert statement that goes out to the database is now successfully serializing the hash instead of giving a 'can't quote' error.

##  Post Merge Notes

Will need a matching PR in edison, springbuk, and data_management to make this version active once this PR is merged.