### PR TITLE
MOJ-150 MOJ-151 Snowflake type mapping & array_of... types for

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -14,6 +14,8 @@ require 'odbc_adapter/database_metadata'
 require 'odbc_adapter/registry'
 require 'odbc_adapter/version'
 
+require 'odbc_adapter/type/array'
+
 module ActiveRecord
   class Base
     class << self
@@ -156,7 +158,9 @@ module ActiveRecord
         map.register_type :binary,                Type::Binary.new
         map.register_type :float,                 Type::Float.new
         map.register_type :integer,               Type::Integer.new
-        map.register_type :decimal,               Type::Decimal.new
+        map.register_type(:decimal) do |_sql_type, column_data|
+          Type::Decimal.new(precision: column_data.precision, scale: column_data.scale)
+        end
       end
 
       # Translate an exception from the native DBMS to something usable by

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -65,6 +65,10 @@ module ODBCAdapter
       "#{table}_seq"
     end
 
+    def empty_insert_statement_value(primary_key = nil)
+      "(#{primary_key}) VALUES (DEFAULT)"
+    end
+
     private
 
     # A custom hook to allow end users to overwrite the type casting before it

--- a/lib/odbc_adapter/quoting.rb
+++ b/lib/odbc_adapter/quoting.rb
@@ -40,7 +40,7 @@ module ODBCAdapter
     end
 
     def lookup_cast_type_from_column(column) # :nodoc:
-      type_map.lookup(column.type)
+      type_map.lookup(column.type, column)
     end
   end
 end

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -75,7 +75,6 @@ module ODBCAdapter
         next unless col[0] =~ db_regex && col[1] =~ schema_regex
         col_name        = col[3]  # SQLColumns: COLUMN_NAME
         col_default     = col[12] # SQLColumns: COLUMN_DEF
-        col_sql_type    = col[4]  # SQLColumns: DATA_TYPE
         col_native_type = col[5]  # SQLColumns: TYPE_NAME
         col_limit       = col[6]  # SQLColumns: COLUMN_SIZE
         col_scale       = col[8]  # SQLColumns: DECIMAL_DIGITS
@@ -85,20 +84,27 @@ module ODBCAdapter
 
         # This section has been customized for Snowflake and will not work in general.
         args = { sql_type: col_native_type, type: col_native_type, limit: col_limit }
-        args[:type] = :boolean if col_native_type == "BOOLEAN"  # self.class::BOOLEAN_TYPE
-        args[:type] = :json if col_native_type == "VARIANT" || col_native_type == "JSON"
-        args[:type] = :date if col_native_type == "DATE"
-        args[:type] = :string if col_native_type == "VARCHAR"
-        args[:type] = :datetime if col_native_type == "TIMESTAMP"
-        args[:type] = :time if col_native_type == "TIME"
-        args[:type] = :binary if col_native_type == "BINARY"
-        args[:type] = :float if col_native_type == "DOUBLE"
+        args[:type] = case col_native_type
+                      when "BOOLEAN" then :boolean
+                      when "VARIANT", "ARRAY", "STRUCT" then :json
+                      when "DATE" then :date
+                      when "VARCHAR" then :string
+                      when "TIMESTAMP" then :datetime
+                      when "TIME" then :time
+                      when "BINARY" then :binary
+                      when "DOUBLE" then :float
+                      when "DECIMAL"
+                        if col_scale == 0
+                          :integer
+                        else
+                          args[:scale]     = col_scale
+                          args[:precision] = col_limit
+                          :decimal
+                        end
+                      else
+                        nil
+                      end
 
-        if [ODBC::SQL_DECIMAL, ODBC::SQL_NUMERIC].include?(col_sql_type)
-          args[:type] = col_scale == 0 ? :integer : :decimal
-          args[:scale]     = col_scale || 0
-          args[:precision] = col_limit
-        end
         sql_type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(**args)
 
         # The @connection.columns function returns empty strings for column defaults.

--- a/lib/odbc_adapter/type/array.rb
+++ b/lib/odbc_adapter/type/array.rb
@@ -1,0 +1,39 @@
+module ODBCAdapter
+  module Type
+    def Type.array(type)
+      newArrayClass = Class.new(ActiveRecord::Type::Value)
+      newArrayClass.define_method :cast_value do |value|
+        base_array = ActiveSupport::JSON.decode(value) rescue nil
+        base_array.map do |element|
+          ret = type.cast(element)
+          ret
+        end
+      end
+
+      newArrayClass.define_method :serialize do |value|
+        ActiveSupport::JSON.encode(value.map { |element| type.serialize(element)}) unless value.nil?
+      end
+
+      newArrayClass.define_method :changed_in_place? do |raw_old_value, new_value|
+        deserialize(raw_old_value) != new_value
+      end
+
+      newArrayClass
+    end
+  end
+
+
+end
+
+ActiveRecord::Type.register(:array_of_big_integers, ODBCAdapter::Type.array(ActiveRecord::Type::BigInteger.new))
+ActiveRecord::Type.register(:array_of_binaries, ODBCAdapter::Type.array(ActiveRecord::Type::Binary.new))
+ActiveRecord::Type.register(:array_of_booleans, ODBCAdapter::Type.array(ActiveRecord::Type::Boolean.new))
+ActiveRecord::Type.register(:array_of_dates, ODBCAdapter::Type.array(ActiveRecord::Type::Date.new))
+ActiveRecord::Type.register(:array_of_date_times, ODBCAdapter::Type.array(ActiveRecord::Type::DateTime.new))
+ActiveRecord::Type.register(:array_of_decimals, ODBCAdapter::Type.array(ActiveRecord::Type::Decimal.new))
+ActiveRecord::Type.register(:array_of_floats, ODBCAdapter::Type.array(ActiveRecord::Type::Float.new))
+ActiveRecord::Type.register(:array_of_immutable_strings, ODBCAdapter::Type.array(ActiveRecord::Type::ImmutableString.new))
+ActiveRecord::Type.register(:array_of_integers, ODBCAdapter::Type.array(ActiveRecord::Type::Integer.new))
+ActiveRecord::Type.register(:array_of_strings, ODBCAdapter::Type.array(ActiveRecord::Type::String.new))
+ActiveRecord::Type.register(:array_of_times, ODBCAdapter::Type.array(ActiveRecord::Type::Time.new))
+ActiveRecord::Type.register(:array_of_values, ODBCAdapter::Type.array(ActiveRecord::Type::Value.new))


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/MOJ-150
https://springbuk-glass.atlassian.net/browse/MOJ-151

## Problem

Snowflake doesn't support typed arrays, but having ruby understand them anyways is useful. Develop array_of_<type> classes that can be used in attribute tags on models so the model understands these are typed arrays.
Add type mapping for the remaining native types that are returned when querying snowflake table column types.

## Solution

Add array_of_intgers, array_of_binaries, etc... types that can be used with attribute tagging to quickly perform useful type coercion.
Adds mapping for the remaining snowflake types, removes mapping for JSON type (as this isn't actually a type returned by snowflake ever)

## Testing/QA Notes

I'll encourage you to pull down this commit to your local environment. Just updating the gemfile to point at this commit rather than master should work. Start up edison, enter the container with a bash and then `rails c`. I created dummy tables called TYPE_TEST and ARR_TYPE_TEST in SB2 that contain various typed columns.

A dummy model in edison
```
# frozen_string_literal: true

class TypeTest < ApplicationRecord
  self.table_name = "type_test"
end
```
will allow you to use the model to test that typing works.

Note: Inserting on any of structured data types (array, object, variant) is broken still. There is another story MOJ-154 to resolve this.

##  Post Merge Notes

Drop the ARR_TYPE_TEST and TYPE_TEST tables from SB2 when this is merged.