### PR TITLE
Moj 450 update with prefetch primary key

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -146,6 +146,15 @@ module ActiveRecord
         ::ODBCAdapter::Column.new(name, default, sql_type_metadata, null, native_type)
       end
 
+      #Snowflake doesn't have a mechanism to return the primary key on inserts, it needs prefetched
+      def prefetch_primary_key?(table_name = nil)
+        true
+      end
+
+      def next_sequence_value(table_name = nil)
+        exec_query("SELECT #{table_name}.NEXTVAL as new_id").first["new_id"]
+      end
+
       protected
 
       #Snowflake ODBC Adapter specific

--- a/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
+++ b/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
@@ -1,7 +1,6 @@
 module ODBCAdapter
   module InsertAttributeStripper
     extend ActiveSupport::Concern
-    include EasyIdentified
 
     included do
       alias_method :pre_insert_attribute_stripper_save, :save
@@ -33,6 +32,7 @@ module ODBCAdapter
             stripped_attributes = {}
           end
           first_call_result = base_function.call(**options, &block)
+          return false if first_call_result == false
           if stripped_attributes.any?
             restore_stripped_attributes(stripped_attributes)
             return base_function.call(**options, &block)

--- a/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
+++ b/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
@@ -29,7 +29,6 @@ module ODBCAdapter
                 self[column.name] = nil
               end
             end
-            if stripped_attributes.any? then generate_id end
           else
             stripped_attributes = {}
           end


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/MOJ-450

## Problem

The current method of pregenerating primary keys only works where we’ve got direct access to the code, is cumbersome, and requires specialized knowledge

## Solution

Implement the `prefetch_primary_key?` and `next_sequence_value` methods on the adapter so that it'll automatically handle this for us.
Minor tweaks to InsertAttributeStripper since EasyIdentified isn't effectively deprecated by this change.

## Testing/QA Notes

Check through QA if there's anything not covered by QA wolf you'd want to see.

## Testing/QA Parties

None

##  Post Merge Notes

Will need PRs to springbuk, edison, and probably DM to update the adapter.