### PR TITLE
MOJ-366 Two updates for added functionality

### DIFF
--- a/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
+++ b/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
@@ -23,7 +23,7 @@ module ODBCAdapter
         # errors normally for an invalid record. We then disable validations during the initial save, because we'll
         # often be saving a technically invalid record as we've stripped off required elements.
         unless options[:validate] == false || valid?
-          return base_function.call(**temp_options, &block)
+          return base_function.call(**options, &block)
         end
         self.class.transaction do
           if new_record?

--- a/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
+++ b/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
@@ -23,7 +23,7 @@ module ODBCAdapter
         # errors normally for an invalid record. We then disable validations during the initial save, because we'll
         # often be saving a technically invalid record as we've stripped off required elements.
         unless options[:validate] == false || valid?
-          raise_validation_error
+          return base_function.call(**temp_options, &block)
         end
         self.class.transaction do
           if new_record?

--- a/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
+++ b/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
@@ -19,6 +19,12 @@ module ODBCAdapter
       UNSAFE_INSERT_TYPES ||= %i(variant object array)
 
       def save_internal(base_function, **options, &block)
+        # Unless the validations are turned off or the hash is valid just run the save. This will trigger validation
+        # errors normally for an invalid record. We then disable validations during the initial save, because we'll
+        # often be saving a technically invalid record as we've stripped off required elements.
+        unless options[:validate] == false || valid?
+          raise_validation_error
+        end
         self.class.transaction do
           if new_record?
             stripped_attributes = {}
@@ -31,7 +37,8 @@ module ODBCAdapter
           else
             stripped_attributes = {}
           end
-          first_call_result = base_function.call(**options, &block)
+          temp_options = options.merge(validate: false)
+          first_call_result = base_function.call(**temp_options, &block)
           return false if first_call_result == false
           if stripped_attributes.any?
             restore_stripped_attributes(stripped_attributes)

--- a/lib/odbc_adapter/type/object.rb
+++ b/lib/odbc_adapter/type/object.rb
@@ -15,6 +15,10 @@ module ODBCAdapter
       def changed_in_place?(raw_old_value, new_value)
         deserialize(raw_old_value) != new_value
       end
+
+      def accessor
+        ActiveRecord::Store::StringKeyedHashAccessor
+      end
     end
   end
 end

--- a/lib/odbc_adapter/type/variant.rb
+++ b/lib/odbc_adapter/type/variant.rb
@@ -19,6 +19,10 @@ module ODBCAdapter
       def changed_in_place?(raw_old_value, new_value)
         deserialize(raw_old_value) != new_value
       end
+
+      def accessor
+        ActiveRecord::Store::StringKeyedHashAccessor
+      end
     end
   end
 end


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/MOJ-366

## Problem

Discovered while moving the ai_question_templates table that snowflake variant & object fields don't support store_accessor.
Continued issues with records failing validation related to the InsertAttributeStripper made me realize we could just run the validation before stripping off attributes, but then disable validation when we do the actual insert.

## Solution

Variant & object types now support store_accessor
InsertAttributeStripper now validates records before stripping off attributes and then disables validation during the initial save.

## Testing/QA Notes

Check through QA if there's anything not covered by QA wolf you'd want to see.

## Testing/QA Parties

None

##  Post Merge Notes

Will need PRs to springbuk, edison, and probably DM to update the adapter.