### PR TITLE
[MOJ-451] Migrations fail when using :boolean

### DIFF
--- a/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
@@ -3,7 +3,7 @@ module ODBCAdapter
     # Overrides specific to PostgreSQL. Mostly taken from
     # ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
     class PostgreSQLODBCAdapter < ActiveRecord::ConnectionAdapters::ODBCAdapter
-      BOOLEAN_TYPE = 'bool'.freeze
+      BOOLEAN_TYPE = 'boolean'.freeze
       PRIMARY_KEY  = 'SERIAL PRIMARY KEY'.freeze
       VARIANT_TYPE = 'VARIANT'.freeze
       DATE_TYPE = 'DATE'.freeze
@@ -13,7 +13,7 @@ module ODBCAdapter
 
       # Override to handle booleans appropriately
       def native_database_types
-        @native_database_types ||= super.merge(boolean: { name: 'bool' })
+        @native_database_types ||= super.merge(boolean: { name: 'boolean' })
       end
 
       def arel_visitor


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/MOJ-451

## Problem

Rails migrations that use `:boolean` as a data type fail. The odbc_adapter code uses 'bool' in the generated SQL for the symbol `:boolean`. "bool" is a Postgres alias for "boolean". Snowflake does not support that alias.

## Solution

"boolean" must be used instead of "bool" in the generated SQL.

## Testing/QA Notes

Create and test a migration.

##  Post Merge Notes

Will need PRs to springbuk, edison, and probably DM to update the adapter.