### PR TITLE
[COR-3018] Support Rails 7

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -203,7 +203,8 @@ module ActiveRecord
       # numeric
       def alias_type(map, new_type, old_type)
         map.register_type(new_type) do |_, *args|
-          map.lookup(old_type, *args)
+          puts "odbc_adapter  ConnectionAdapters  alias_type"
+          map.lookup(old_type)
         end
       end
 

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -202,8 +202,7 @@ module ActiveRecord
       # work with non-string keys, and in our case the keys are (almost) all
       # numeric
       def alias_type(map, new_type, old_type)
-        map.register_type(new_type) do |_, *args|
-          puts "odbc_adapter  ConnectionAdapters  alias_type"
+        map.register_type(new_type) do |_|
           map.lookup(old_type)
         end
       end

--- a/lib/odbc_adapter/quoting.rb
+++ b/lib/odbc_adapter/quoting.rb
@@ -40,7 +40,8 @@ module ODBCAdapter
     end
 
     def lookup_cast_type_from_column(column) # :nodoc:
-      type_map.lookup(column.type, column)
+      puts "odbc_adapter  Quoting  lookup_cast_type_from_column"
+      type_map.lookup(column.type)
     end
 
     def quote_hash(hash:)

--- a/lib/odbc_adapter/quoting.rb
+++ b/lib/odbc_adapter/quoting.rb
@@ -40,7 +40,6 @@ module ODBCAdapter
     end
 
     def lookup_cast_type_from_column(column) # :nodoc:
-      puts "odbc_adapter  Quoting  lookup_cast_type_from_column"
       type_map.lookup(column.type)
     end
 


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/COR-3018

## Problem

Rails database migrations for Snowflake that use add_column fail. A Rails internal call used by odbc_adapter has changed. The second argument has been dropped.

## Solution

Modify the calls in odbc_adpater to the function to remove the second argument.

## Testing/QA Notes

Test with the file db/snowflake_migrate/20230202192912_add_icd_version_fields_to_master_expert_medical_opinions_table.rb inan environment that includes the Rails 7 migration.

I tested this in my local data_management environment using the migration listed above with Snowflake enabled. Using master, the Snowflake migration and reversal were successful. Switched to the Rails 7 migration branch. The Snowflake migration failed with the expected error. Updated the `Gemfile.lock` with the SHA from this branch. The Snowflake migration and reversal were successful.

##  Post Merge Notes

Update the `odbc_adapter` revision in `Gemfile.lock` as part of Rails 7 migrations in the repos that use odbc_adapter.
