### PR TITLE
Moj 574 speedup hr uploads processing

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -155,6 +155,19 @@ module ActiveRecord
         exec_query("SELECT #{table_name}.NEXTVAL as new_id").first["new_id"]
       end
 
+      def build_merge_sql(merge) # :nodoc:
+        <<~SQL
+          MERGE #{merge.into} AS TARGET USING (#{merge.values_list}) AS SOURCE ON #{merge.match}
+          #{merge.merge_delete}
+          #{merge.merge_update}
+          #{merge.merge_insert}
+        SQL
+      end
+
+      def exec_merge_all(sql, name) # :nodoc:
+        exec_query(sql, name)
+      end
+
       protected
 
       #Snowflake ODBC Adapter specific

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -180,7 +180,6 @@ module ActiveRecord
         map.register_type %r(binary)i,                Type::Binary.new
         map.register_type %r(double)i,                 Type::Float.new
         map.register_type(%r(decimal)i) do |sql_type|
-          p sql_type
           scale = extract_scale(sql_type)
           if scale == 0
             ::ODBCAdapter::Type::SnowflakeInteger.new

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -172,20 +172,25 @@ module ActiveRecord
 
       #Snowflake ODBC Adapter specific
       def initialize_type_map(map)
-        map.register_type :boolean,               Type::Boolean.new
-        map.register_type :date,                  Type::Date.new
-        map.register_type :string,                Type::String.new
-        map.register_type :datetime,              Type::DateTime.new
-        map.register_type :time,                  Type::Time.new
-        map.register_type :binary,                Type::Binary.new
-        map.register_type :float,                 Type::Float.new
-        map.register_type :integer,               ::ODBCAdapter::Type::SnowflakeInteger.new
-        map.register_type(:decimal) do |_sql_type, column_data|
-          Type::Decimal.new(precision: column_data.precision, scale: column_data.scale)
+        map.register_type %r(boolean)i,               Type::Boolean.new
+        map.register_type %r(date)i,                  Type::Date.new
+        map.register_type %r(varchar)i,                Type::String.new
+        map.register_type %r(time)i,                  Type::Time.new
+        map.register_type %r(timestamp)i,              Type::DateTime.new
+        map.register_type %r(binary)i,                Type::Binary.new
+        map.register_type %r(double)i,                 Type::Float.new
+        map.register_type(%r(decimal)i) do |sql_type|
+          p sql_type
+          scale = extract_scale(sql_type)
+          if scale == 0
+            ::ODBCAdapter::Type::SnowflakeInteger.new
+          else
+            Type::Decimal.new(precision: extract_precision(sql_type), scale: scale)
+          end
         end
-        map.register_type :object,                ::ODBCAdapter::Type::SnowflakeObject.new
-        map.register_type :array,                 ::ODBCAdapter::Type::ArrayOfValues.new
-        map.register_type :variant,               ::ODBCAdapter::Type::Variant.new
+        map.register_type %r(struct)i,                ::ODBCAdapter::Type::SnowflakeObject.new
+        map.register_type %r(array)i,                 ::ODBCAdapter::Type::ArrayOfValues.new
+        map.register_type %r(variant)i,               ::ODBCAdapter::Type::Variant.new
       end
 
       # Translate an exception from the native DBMS to something usable by

--- a/lib/active_record/merge_all.rb
+++ b/lib/active_record/merge_all.rb
@@ -35,11 +35,11 @@ module ActiveRecord
     end
 
     def updatable_columns
-      keys - readonly_columns - delete_keys
+      keys - readonly_columns - [delete_key]
     end
 
     def insertable_columns
-      keys - delete_keys
+      keys - [delete_key]
     end
 
     def insertable_non_primary_columns

--- a/lib/active_record/merge_all.rb
+++ b/lib/active_record/merge_all.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/enumerable"
+
+module ActiveRecord
+  class MergeAll # :nodoc:
+    attr_reader :model, :connection, :merges, :keys
+    attr_reader :perform_inserts, :perform_updates, :delete_keys
+
+    def initialize(model, merges, perform_inserts: true, perform_updates: true, delete_keys: [])
+      raise ArgumentError, "Empty list of attributes passed" if merges.blank?
+
+      @model, @connection, @merges, @keys = model, model.connection, merges, merges.first.keys.map(&:to_s)
+      @perform_inserts, @perform_updates, @delete_keys = perform_inserts, perform_updates, delete_keys.map(&:to_s)
+
+      if model.scope_attributes?
+        @scope_attributes = model.scope_attributes
+        @keys |= @scope_attributes.keys
+      end
+      @keys = @keys.to_set
+
+      ensure_valid_options_for_connection!
+    end
+
+    def execute
+      message = +"#{model} "
+      message << "Bulk " if merges.many?
+      message << "Merge"
+      connection.exec_merge_all to_sql, message
+    end
+
+    def updatable_columns
+      keys - readonly_columns - delete_keys
+    end
+
+    def insertable_columns
+      keys - delete_keys
+    end
+
+    def insertable_non_primary_columns
+      insertable_columns - primary_keys
+    end
+
+    def primary_keys
+      Array(connection.schema_cache.primary_keys(model.table_name))
+    end
+
+    def map_key_with_value
+      merges.map do |attributes|
+        attributes = attributes.stringify_keys
+        attributes.merge!(scope_attributes) if scope_attributes
+
+        verify_attributes(attributes)
+
+        keys.map do |key|
+          yield key, attributes[key]
+        end
+      end
+    end
+
+    def perform_deletes
+      !delete_keys.empty?
+    end
+
+    private
+    attr_reader :scope_attributes
+
+    def ensure_valid_options_for_connection!
+
+    end
+
+    def to_sql
+      connection.build_merge_sql(ActiveRecord::MergeAll::Builder.new(self))
+    end
+
+    def readonly_columns
+      primary_keys + model.readonly_attributes.to_a
+    end
+
+    def verify_attributes(attributes)
+      if keys != attributes.keys.to_set
+        raise ArgumentError, "All objects being merged must have the same keys"
+      end
+    end
+
+    class Builder # :nodoc:
+      attr_reader :model
+
+      delegate :keys, to: :merge_all
+
+      def initialize(merge_all)
+        @merge_all, @model, @connection = merge_all, merge_all.model, merge_all.connection
+      end
+
+      def into
+        # "INTO #{model.quoted_table_name} (#{columns_list})"
+        "INTO #{model.quoted_table_name}"
+      end
+
+      def values_list
+        types = extract_types_from_columns_on(model.table_name, keys: keys)
+
+        values_list = merge_all.map_key_with_value do |key, value|
+          connection.with_yaml_fallback(types[key].serialize(value))
+        end
+
+        values = connection.visitor.compile(Arel::Nodes::ValuesList.new(values_list))
+
+        "SELECT * FROM (#{values}) AS v1 (#{columns_list})"
+      end
+
+      def match
+        quote_columns(merge_all.primary_keys).map { |column| "SOURCE.#{column}=TARGET.#{column}" }.join(" AND ")
+      end
+
+      def merge_delete
+        merge_all.perform_deletes ? "WHEN MATCHED AND #{quote_columns(merge_all.delete_keys).map { |column| "SOURCE.#{column} = TRUE"}.join(" AND ")} THEN DELETE" : ""
+      end
+
+      def merge_update
+        merge_all.perform_updates ? "WHEN MATCHED THEN UPDATE SET #{updatable_columns.map { |column| "TARGET.#{column}=SOURCE.#{column}" }.join(",")}" : ""
+      end
+
+      def merge_insert
+        if merge_all.perform_inserts
+          <<~SQL
+            WHEN NOT MATCHED AND #{quote_columns(merge_all.primary_keys).map { |column| "SOURCE.#{column} IS NOT NULL" }.join(" AND ")} THEN INSERT (#{insertable_columns_list}) VALUES (#{quote_columns(merge_all.insertable_columns).map { |column| "SOURCE.#{column}"}.join(",")})
+            WHEN NOT MATCHED AND #{quote_columns(merge_all.primary_keys).map { |column| "SOURCE.#{column} IS NULL" }.join(" OR ")} THEN INSERT (#{insertable_non_primary_columns_list}) VALUES (#{quote_columns(merge_all.insertable_non_primary_columns).map { |column| "SOURCE.#{column}"}.join(",")})
+          SQL
+        else
+          ""
+        end
+      end
+
+      private
+      attr_reader :connection, :merge_all
+
+      def columns_list
+        format_columns(merge_all.keys)
+      end
+
+      def insertable_columns_list
+        format_columns(merge_all.insertable_columns)
+      end
+
+      def insertable_non_primary_columns_list
+        format_columns(merge_all.insertable_non_primary_columns)
+      end
+
+      def updatable_columns
+        quote_columns(merge_all.updatable_columns)
+      end
+
+      def extract_types_from_columns_on(table_name, keys:)
+        columns = connection.schema_cache.columns_hash(table_name)
+
+        unknown_column = (keys - columns.keys).first
+        raise UnknownAttributeError.new(model.new, unknown_column) if unknown_column
+
+        keys.index_with { |key| model.type_for_attribute(key) }
+      end
+
+      def format_columns(columns)
+        columns.respond_to?(:map) ? quote_columns(columns).join(",") : columns
+      end
+
+      def quote_columns(columns)
+        columns.map(&connection.method(:quote_column_name))
+      end
+    end
+  end
+end

--- a/lib/active_record/merge_all.rb
+++ b/lib/active_record/merge_all.rb
@@ -77,9 +77,11 @@ module ActiveRecord
       unless primary_keys.to_set.subset?(keys)
         raise ArgumentError, "Pruning duplicates requires presense of all primary keys in the merges"
       end
-      @merges = merges.reverse.uniq do |merge|
+      @merges = merges.reverse
+      merges.uniq! do |merge|
         primary_keys.map { |key| merge[key] }
-      end.reverse
+      end
+      merges.reverse!
     end
 
     def to_sql

--- a/lib/active_record/merge_all_persistence.rb
+++ b/lib/active_record/merge_all_persistence.rb
@@ -1,0 +1,14 @@
+require 'active_record/merge_all'
+
+module ActiveRecord
+  # = Active Record \Persistence
+  module MergeAllPersistence
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def merge_all!(attributes, perform_inserts: true, perform_updates: true, delete_keys: [])
+        MergeAll.new(self, attributes, perform_inserts: perform_inserts, perform_updates: perform_updates, delete_keys: delete_keys).execute
+      end
+    end
+  end
+end

--- a/lib/active_record/merge_all_persistence.rb
+++ b/lib/active_record/merge_all_persistence.rb
@@ -6,8 +6,8 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def merge_all!(attributes, perform_inserts: true, perform_updates: true, delete_keys: [], prune_duplicates: false)
-        MergeAll.new(self, attributes, perform_inserts: perform_inserts, perform_updates: perform_updates, delete_keys: delete_keys, prune_duplicates: prune_duplicates).execute
+      def merge_all!(attributes, perform_inserts: true, perform_updates: true, prune_duplicates: false)
+        MergeAll.new(self, attributes, perform_inserts: perform_inserts, perform_updates: perform_updates, prune_duplicates: prune_duplicates).execute
       end
     end
   end

--- a/lib/active_record/merge_all_persistence.rb
+++ b/lib/active_record/merge_all_persistence.rb
@@ -6,8 +6,8 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def merge_all!(attributes, perform_inserts: true, perform_updates: true, delete_keys: [])
-        MergeAll.new(self, attributes, perform_inserts: perform_inserts, perform_updates: perform_updates, delete_keys: delete_keys).execute
+      def merge_all!(attributes, perform_inserts: true, perform_updates: true, delete_keys: [], prune_duplicates: false)
+        MergeAll.new(self, attributes, perform_inserts: perform_inserts, perform_updates: perform_updates, delete_keys: delete_keys, prune_duplicates: prune_duplicates).execute
       end
     end
   end

--- a/lib/odbc_adapter.rb
+++ b/lib/odbc_adapter.rb
@@ -1,2 +1,3 @@
 # Requiring with this pattern to mirror ActiveRecord
 require 'active_record/connection_adapters/odbc_adapter'
+require 'active_record/merge_all_persistence'

--- a/lib/odbc_adapter/quoting.rb
+++ b/lib/odbc_adapter/quoting.rb
@@ -40,7 +40,7 @@ module ODBCAdapter
     end
 
     def lookup_cast_type_from_column(column) # :nodoc:
-      type_map.lookup(column.type)
+      type_map.lookup(column.sql_type)
     end
 
     def quote_hash(hash:)


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/MOJ-574

## Problem

After converting the HR uploads to snowflake, processing them is extremely slow.

## Solution

Needed functionality to do bulk updates in snowflake. This needs to be done via a merge statement. During implementation, I discovered that there were issues using active record models with the rails 7 changes and needed to resolve those issues. initialize_type_map was changes to work the same way it does with most adapters (using a regex string) and related functionality was also updates to generate type strings that are SQL types.

## Testing/QA Notes

Validate that the adapter runs in QA and that the new merge_all functionality works with the HR uploads.

## Testing/QA Parties

None

##  Post Merge Notes

Update springbuk 574 PR when merged. Remove the specific commit reference from the gemfile and update the lockfile.