### PR TITLE
[MOJ-578] Use new springbuk odbc-ruby gem.

### DIFF
--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -1,3 +1,3 @@
 module ODBCAdapter
-  VERSION = '5.0.6'.freeze
+  VERSION = '5.0.7'.freeze
 end

--- a/odbc_adapter.gemspec
+++ b/odbc_adapter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activerecord', '>= 5.0.1'
-  spec.add_dependency 'ruby-odbc', '~> 0.9'
+  spec.add_dependency 'odbc-ruby', '~> 1.0.0'
 
   spec.add_development_dependency 'bundler', '>= 1.14'
   spec.add_development_dependency 'minitest', '~> 5.10'


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/MOJ-578

## Problem

There are performance issues when pulling more than 500 records from Snowflake using the existing `ruby-odbc` gem.

## Solution

Created a new Springbuk specific version of the `ruby-odbc` gem named `odbc-ruby` which addresses these performance concerns.

## Testing/QA Notes

This should be tested in QA and Sandbox 3.  Pages that access more than 500 records from Snowflake should see performance improvements.

## Testing/QA Parties

N/A

##  Post Merge Notes

Related PRs:
Springbuk: https://github.com/springbuk/springbuk/pull/6649
Springboot: https://github.com/springbuk/springboot/pull/155
Edison: https://github.com/springbuk/edison/pull/878