### PR TITLE
Moj 519 plan years controller

### DIFF
--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -78,7 +78,7 @@ module ODBCAdapter
     end
 
     # Extracts the value from a Snowflake column default definition.
-    def extract_value_from_default(default)
+    def extract_default_from_snowflake(default)
       case default
         # null
       when nil
@@ -88,10 +88,8 @@ module ODBCAdapter
         $1.gsub("''", "'").gsub("\\\\","\\")
         # Boolean types
       when "TRUE"
-        puts "col_default: #{default.inspect}"
         "true"
       when "FALSE"
-        puts "col_default: #{default.inspect}"
         "false"
         # Numeric types
       when /\A(-?\d+(\.\d*)?)\z/
@@ -99,6 +97,46 @@ module ODBCAdapter
       else
         nil
       end
+    end
+
+    def extract_data_type_from_snowflake(snowflake_data_type)
+      case snowflake_data_type
+      when "NUMBER"
+        "DECIMAL"
+      when /\ATIMESTAMP_.*/
+        "TIMESTAMP"
+      when "TEXT"
+        "VARCHAR"
+      when "FLOAT"
+        "DOUBLE"
+      when "FIXED"
+        "DECIMAL"
+      when "REAL"
+        "DOUBLE"
+      else
+        snowflake_data_type
+      end
+    end
+
+    def extract_column_size_from_snowflake(type_information)
+      case type_information["type"]
+      when /\ATIMESTAMP_.*/
+        35
+      when "DATE"
+        10
+      when "FLOAT"
+        38
+      when "REAL"
+        38
+      when "BOOLEAN"
+        1
+      else
+        type_information["length"] || type_information["precision"] || 0
+      end
+    end
+
+    def extract_scale_from_snowflake(type_information)
+      type_information["scale"] || 0
     end
 
     def retrieve_column_data(table_name)
@@ -132,11 +170,51 @@ module ODBCAdapter
         ORDER BY ORDINAL_POSITION
       SQL
 
+      query_results_old = ActiveRecord::Base.logger.silence do
+        exec_query(column_query)
+      end
+
+      column_data_old = query_results_old.map do |query_result|
+        {
+          column_name: query_result["column_name"],
+          col_default: extract_default_from_snowflake(query_result["column_default"]),
+          col_native_type: query_result["data_type"],
+          column_size: query_result["column_size"],
+          numeric_scale: query_result["numeric_scale"],
+          is_nullable: query_result["is_nullable"]
+        }
+      end
+
+      column_query = "SHOW COLUMNS IN TABLE #{native_case(table_name)}"
+
       # Temporarily disable debug logging so we don't spam the log with table column queries
-      logger = ActiveRecord::Base.logger.level
-      ActiveRecord::Base.logger.level = Logger::WARN
-      column_data ||= exec_query(column_query)
-      ActiveRecord::Base.logger.level = logger
+      query_results = ActiveRecord::Base.logger.silence do
+       exec_query(column_query)
+      end
+
+      column_data = query_results.map do |query_result|
+        data_type_parsed = JSON.parse(query_result["data_type"])
+        {
+          column_name: query_result["column_name"],
+          col_default: extract_default_from_snowflake(query_result["default"]),
+          col_native_type: extract_data_type_from_snowflake(data_type_parsed["type"]),
+          column_size: extract_column_size_from_snowflake(data_type_parsed),
+          numeric_scale: extract_scale_from_snowflake(data_type_parsed),
+          is_nullable: data_type_parsed["nullable"]
+        }
+      end
+
+      if column_data_old == column_data
+        puts "COMPARE SUCCESS #{table_name}"
+      else
+        puts "COMPARE FAILED #{table_name}"
+        old_columns = column_data_old.to_a - column_data.to_a
+        new_columns = column_data.to_a - column_data_old.to_a
+        old_columns.map do |old_column|
+          new_column = new_columns.find { |test_column| test_column[:column_name] == old_column[:column_name] }
+          puts("#{old_column} > #{(new_column ? new_column.to_a - old_column.to_a : new_column)}")
+        end
+      end
 
       column_data
     end
@@ -149,12 +227,12 @@ module ODBCAdapter
       result = retrieve_column_data(table_name)
 
       result.each_with_object([]) do |col, cols|
-        col_name        = col["column_name"]
-        col_default     = extract_value_from_default(col["column_default"])
-        col_native_type = col["data_type"]
-        col_limit       = col["column_size"]
-        col_scale       = col["numeric_scale"]
-        col_nullable    = col["is_nullable"]
+        col_name        = col[:column_name]
+        col_default     = col[:col_default]
+        col_native_type = col[:col_native_type]
+        col_limit       = col[:column_size]
+        col_scale       = col[:numeric_scale]
+        col_nullable    = col[:is_nullable]
 
         args = { sql_type: construct_sql_type(col_native_type, col_limit, col_scale), type: col_native_type, limit: col_limit }
         args[:type] = case col_native_type

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -63,7 +63,7 @@ module ODBCAdapter
     end
 
     def retrieve_column_data(table_name)
-      column_query = "SHOW COLUMNS IN TABLE #{native_case(table_name)}"
+      column_query = "SHOW COLUMNS IN TABLE #{table_name}"
 
       # Temporarily disable debug logging so we don't spam the log with table column queries
       query_results = ActiveRecord::Base.logger.silence do

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -191,13 +191,6 @@ module ODBCAdapter
 
         sql_type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(**args)
 
-        # The @connection.columns function returns empty strings for column defaults.
-        # Even when the column has a default value. This is a call to the ODBC layer
-        # with only enough Ruby to make the call happen. Replacing the empty string
-        # with nil permits Rails to set the current datetime for created_at and
-        # updated_at on model creates and updates.
-        col_default = nil if col_default == ""
-
         cols << new_column(format_case(col_name), col_default, sql_type_metadata, col_nullable, col_native_type)
       end
     end

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -62,27 +62,109 @@ module ODBCAdapter
       end
     end
 
+    def columns_test()
+      tables_query = <<~SQL
+        SELECT TABLE_NAME
+        FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_CATALOG = CURRENT_DATABASE() AND TABLE_SCHEMA = CURRENT_SCHEMA()
+      SQL
+      table_list = exec_query(tables_query)
+      ActiveRecord::Base.logger.debug("Retrieving columns for #{table_list.length} tables")
+      table_list.map.with_index do |record, index|
+        ActiveRecord::Base.logger.debug("Retrieving columns for #{record["table_name"]}, #{index+1} of #{table_list.length}")
+        columns(record["table_name"])
+      end
+      nil
+    end
+
+    # Extracts the value from a Snowflake column default definition.
+    def extract_value_from_default(default)
+      case default
+        # null
+      when nil
+        nil
+        # Quoted strings
+      when /\A[(B]?'(.*)'\z/m
+        $1.gsub("''", "'").gsub("\\\\","\\")
+        # Boolean types
+      when "TRUE"
+        puts "col_default: #{default.inspect}"
+        "true"
+      when "FALSE"
+        puts "col_default: #{default.inspect}"
+        "false"
+        # Numeric types
+      when /\A(-?\d+(\.\d*)?)\z/
+        $1
+      else
+        nil
+      end
+    end
+
+    def retrieve_column_data(table_name)
+      if @table_store == nil || @table_store[table_name] == nil
+        column_query = <<~SQL
+          SELECT TABLE_CATALOG,
+          TABLE_SCHEMA,
+          TABLE_NAME,
+          COLUMN_NAME,
+          COLUMN_DEFAULT,
+          CASE
+            WHEN DATA_TYPE = 'NUMBER' THEN 'DECIMAL'
+            WHEN DATA_TYPE like 'TIMESTAMP_%' THEN 'TIMESTAMP'
+            WHEN DATA_TYPE = 'TEXT' THEN 'VARCHAR'
+            WHEN DATA_TYPE = 'FLOAT' THEN 'DOUBLE'
+            ELSE DATA_TYPE
+          END AS DATA_TYPE,
+          CASE
+            WHEN DATA_TYPE like 'TIMESTAMP_%' THEN 35
+            WHEN DATA_TYPE = 'DATE' THEN 10
+            WHEN DATA_TYPE = 'FLOAT' THEN 38
+            WHEN DATA_TYPE = 'BOOLEAN' THEN 1
+            ELSE COALESCE(CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, 0)
+          END AS COLUMN_SIZE,
+          CASE
+            WHEN DATA_TYPE like 'TIMESTAMP_%' THEN DATETIME_PRECISION
+            ELSE COALESCE(NUMERIC_SCALE, 0)
+          END AS NUMERIC_SCALE,
+          IS_NULLABLE = 'YES' AS IS_NULLABLE
+          FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_CATALOG = CURRENT_DATABASE() AND TABLE_SCHEMA = CURRENT_SCHEMA() AND TABLE_NAME = #{quote(native_case(table_name))}
+          ORDER BY ORDINAL_POSITION
+        SQL
+
+        logger = ActiveRecord::Base.logger.level
+        ActiveRecord::Base.logger.level = Logger::WARN
+        column_data ||= exec_query(column_query)
+        ActiveRecord::Base.logger.level = logger
+
+        @table_store = {}
+        column_data.each do | column |
+          @table_store[column["table_name"]] = [] unless @table_store.key?(column["table_name"])
+          @table_store[column["table_name"]].push(column)
+        end
+
+        p "Retrieved initial store"
+      end
+
+      @table_store[native_case(table_name.to_s)]
+    end
+
+
     # Returns an array of Column objects for the table specified by
     # +table_name+.
+    # This entire function has been customized for Snowflake and will not work in general.
     def columns(table_name, _name = nil)
-      stmt   = @connection.columns(native_case(table_name.to_s))
-      result = stmt.fetch_all || []
-      stmt.drop
+      result = retrieve_column_data(table_name)
 
-      db_regex = name_regex(current_database)
-      schema_regex = name_regex(current_schema)
       result.each_with_object([]) do |col, cols|
-        next unless col[0] =~ db_regex && col[1] =~ schema_regex
-        col_name        = col[3]  # SQLColumns: COLUMN_NAME
-        col_default     = col[12] # SQLColumns: COLUMN_DEF
-        col_native_type = col[5]  # SQLColumns: TYPE_NAME
-        col_limit       = col[6]  # SQLColumns: COLUMN_SIZE
-        col_scale       = col[8]  # SQLColumns: DECIMAL_DIGITS
+        col_name        = col["column_name"]
+        col_default     = extract_value_from_default(col["column_default"])
+        col_native_type = col["data_type"]
+        col_limit       = col["column_size"]
+        col_scale       = col["numeric_scale"]
+        col_nullable    = col["is_nullable"]
 
-        # SQLColumns: IS_NULLABLE, SQLColumns: NULLABLE
-        col_nullable = nullability(col_name, col[17], col[10])
-
-        # This section has been customized for Snowflake and will not work in general.
         args = { sql_type: construct_sql_type(col_native_type, col_limit, col_scale), type: col_native_type, limit: col_limit }
         args[:type] = case col_native_type
                       when "BOOLEAN" then :boolean


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/MOJ-540

## Problem

While retrieving the plan_years controller I ran into issues as a result of the obdc adapter not retrieving default values

## Solution

Spent a lot of time reviewing the odbc_ruby library to get a good understanding of why we aren't getting default values. In the end, I wasn't able to see anything being done wrong. I don't have a method of testing the snowflake odbc driver itself to confirm, but my only reasonable solution is that this is an issue with the snowflake driver. If it's not going to return type information, that information can also easily be gotten by querying the information schema so I converted the odbc adapter function that retrieve column data to query the information schema.

## Testing/QA Notes

General browsing of qa and attempting to do updates (such as to cohorts or plan years) should reveal any issues.

##  Post Merge Notes

None