### PR TITLE
APP-3029 Fixes prune duplicates.

### DIFF
--- a/lib/active_record/merge_all.rb
+++ b/lib/active_record/merge_all.rb
@@ -80,7 +80,10 @@ module ActiveRecord
       end
       @merges = merges.reverse
       merges.uniq! do |merge|
-        primary_keys.map { |key| merge[key] }
+        # Map the primary keys to determine uniqueness. If a primary key is nil, return a new empty object to
+        # guarantee a unique value. We don't ever want to throw out records that have a nil primary key as these are
+        # new records.
+        primary_keys.map { |key| merge[key].nil? ? Object.new : merge[key] }
       end
       merges.reverse!
     end


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/APP-3029

## Problem

Issue was reported where HR uploads weren't properly updating biometics.

## Solution

Taking a look at the cause, it turns out the code that I added to remove duplicate entries was too aggressive. It was recognizing nil primary keys, which were used to indicate a new records to be inserted, as all being the same record ID so it would prune all but the last record to be inserted.

All records with a nil primary key get their primary key replaced by a new object, which will never compare true to anything else.

## Testing/QA Notes

Attempt to use the merge_all functionality with a mixture of new and update records to confirm that both work.

ODBC adapter changes are also deployed to APP QA

##  Post Merge Notes

Create PR to merge updated ODBC adapter into springbuk gemfile