### PR TITLE
Update adapter to handle rails 7

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -95,6 +95,7 @@ module ActiveRecord
         configure_time_options(connection)
         super(connection, logger, config)
         @database_metadata = database_metadata
+        @connection = connection
       end
 
       # Returns the human-readable name of the adapter.

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -95,7 +95,7 @@ module ActiveRecord
         configure_time_options(connection)
         super(connection, logger, config)
         @database_metadata = database_metadata
-        @connection = connection
+        @raw_connection = connection
       end
 
       # Returns the human-readable name of the adapter.
@@ -120,7 +120,7 @@ module ActiveRecord
       # includes checking whether the database is actually capable of
       # responding, i.e. whether the connection isn't stale.
       def active?
-        @connection.connected?
+        @raw_connection.connected?
       end
 
       # Disconnects from the database if already connected, and establishes a
@@ -128,20 +128,20 @@ module ActiveRecord
       def reconnect
         disconnect!
         odbc_module = @config[:encoding] == 'utf8' ? ODBC_UTF8 : ODBC
-        @connection =
+        @raw_connection =
           if @config.key?(:dsn)
             odbc_module.connect(@config[:dsn], @config[:username], @config[:password])
           else
             odbc_module::Database.new.drvconnect(@config[:driver])
           end
-        configure_time_options(@connection)
+        configure_time_options(@raw_connection)
       end
       alias reset! reconnect!
 
       # Disconnects from the database if already connected. Otherwise, this
       # method does nothing.
       def disconnect!
-        @connection.disconnect if @connection.connected?
+        @raw_connection.disconnect if @raw_connection.connected?
       end
 
       # Build a new column object from the given options. Effectively the same

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -120,7 +120,7 @@ module ActiveRecord
 
       # Disconnects from the database if already connected, and establishes a
       # new connection with the database.
-      def reconnect!
+      def reconnect!(restore_transactions: false)
         disconnect!
         odbc_module = @config[:encoding] == 'utf8' ? ODBC_UTF8 : ODBC
         @connection =

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -109,6 +109,11 @@ module ActiveRecord
         true
       end
 
+      # ODBC adapter does not support the returning clause
+      def supports_insert_returning?
+        false
+      end
+
       # CONNECTION MANAGEMENT ====================================
 
       # Checks whether the connection to the database is still active. This
@@ -143,8 +148,8 @@ module ActiveRecord
       # Build a new column object from the given options. Effectively the same
       # as super except that it also passes in the native type.
       # rubocop:disable Metrics/ParameterLists
-      def new_column(name, default, sql_type_metadata, null, native_type = nil)
-        ::ODBCAdapter::Column.new(name, default, sql_type_metadata, null, native_type)
+      def new_column(name, default, sql_type_metadata, null, native_type = nil, auto_incremented = false)
+        ::ODBCAdapter::Column.new(name, default, sql_type_metadata, null, native_type, auto_incremented)
       end
 
       #Snowflake doesn't have a mechanism to return the primary key on inserts, it needs prefetched
@@ -167,6 +172,11 @@ module ActiveRecord
 
       def exec_merge_all(sql, name) # :nodoc:
         exec_query(sql, name)
+      end
+
+      # odbc_adapter does not support returning, so there are no return values from an insert
+      def return_value_after_insert?(column) # :nodoc:
+        column.auto_incremented
       end
 
       protected

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -125,7 +125,7 @@ module ActiveRecord
 
       # Disconnects from the database if already connected, and establishes a
       # new connection with the database.
-      def reconnect!(restore_transactions: false)
+      def reconnect
         disconnect!
         odbc_module = @config[:encoding] == 'utf8' ? ODBC_UTF8 : ODBC
         @connection =

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -135,7 +135,6 @@ module ActiveRecord
             odbc_module::Database.new.drvconnect(@config[:driver])
           end
         configure_time_options(@connection)
-        super
       end
       alias reset! reconnect!
 

--- a/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
@@ -33,9 +33,9 @@ module ODBCAdapter
       # Returns the sequence name for a table's primary key or some other
       # specified key.
       def default_sequence_name(table_name, pk = nil)
-        next_sequence_value("#{table_name}_id_seq")
+        serial_sequence("#{table_name}_id_seq")
       rescue ActiveRecord::StatementInvalid
-        "#{table_name}_#{'id'}_seq"
+        "#{table_name}_#{pk || 'id'}_seq"
       end
 
       def sql_for_insert(sql, pk, binds)
@@ -180,8 +180,10 @@ module ODBCAdapter
         Integer(r.rows.first.first)
       end
 
-      def next_sequence_value(table)
-        super(table)
+      private
+
+      def serial_sequence(table_sequence_name)
+        exec_query("SELECT #{table_sequence_name}.NEXTVAL as new_id").first["new_id"]
       end
     end
   end

--- a/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
@@ -36,16 +36,6 @@ module ODBCAdapter
         "#{table_name}_#{pk || 'id'}_seq"
       end
 
-      def sql_for_insert(sql, pk, binds)
-        unless pk
-          table_ref = extract_table_ref_from_insert_sql(sql)
-          pk = primary_key(table_ref) if table_ref
-        end
-
-        sql = "#{sql} RETURNING #{quote_column_name(pk)}" if pk
-        [sql, binds]
-      end
-
       def type_cast(value, column)
         return super unless column
 

--- a/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
@@ -33,8 +33,6 @@ module ODBCAdapter
       # Returns the sequence name for a table's primary key or some other
       # specified key.
       def default_sequence_name(table_name, pk = nil)
-        serial_sequence("#{table_name}_id_seq")
-      rescue ActiveRecord::StatementInvalid
         "#{table_name}_#{pk || 'id'}_seq"
       end
 
@@ -178,12 +176,6 @@ module ODBCAdapter
       def last_insert_id(sequence_name)
         r = exec_query("SELECT currval('#{sequence_name}')", 'SQL')
         Integer(r.rows.first.first)
-      end
-
-      private
-
-      def serial_sequence(table_sequence_name)
-        exec_query("SELECT #{table_sequence_name}.NEXTVAL as new_id").first["new_id"]
       end
     end
   end

--- a/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
@@ -33,9 +33,9 @@ module ODBCAdapter
       # Returns the sequence name for a table's primary key or some other
       # specified key.
       def default_sequence_name(table_name, pk = nil)
-        serial_sequence(table_name, pk || 'id').split('.').last
+        next_sequence_value(table_name)
       rescue ActiveRecord::StatementInvalid
-        "#{table_name}_#{pk || 'id'}_seq"
+        "#{table_name}_#{'id'}_seq"
       end
 
       def sql_for_insert(sql, pk, binds)
@@ -180,13 +180,8 @@ module ODBCAdapter
         Integer(r.rows.first.first)
       end
 
-      private
-
-      def serial_sequence(table, column)
-        result = exec_query(<<-eosql, 'SCHEMA')
-          SELECT pg_get_serial_sequence('#{table}', '#{column}')
-        eosql
-        result.rows.first.first
+      def next_sequence_value(table)
+        super(table)
       end
     end
   end

--- a/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
@@ -33,7 +33,7 @@ module ODBCAdapter
       # Returns the sequence name for a table's primary key or some other
       # specified key.
       def default_sequence_name(table_name, pk = nil)
-        next_sequence_value(table_name)
+        next_sequence_value("#{table_name}_id_seq")
       rescue ActiveRecord::StatementInvalid
         "#{table_name}_#{'id'}_seq"
       end

--- a/lib/odbc_adapter/column.rb
+++ b/lib/odbc_adapter/column.rb
@@ -1,13 +1,14 @@
 module ODBCAdapter
   class Column < ActiveRecord::ConnectionAdapters::Column
-    attr_reader :native_type
+    attr_reader :native_type, :auto_incremented
 
     # Add the native_type accessor to allow the native DBMS to report back what
     # it uses to represent the column internally.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(name, default, sql_type_metadata = nil, null = true, native_type = nil, **kwargs)
+    def initialize(name, default, sql_type_metadata = nil, null = true, native_type = nil, auto_incremented, **kwargs)
       super(name, default, sql_type_metadata, null, **kwargs)
       @native_type = native_type
+      @auto_incremented = auto_incremented
     end
   end
 end

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -32,6 +32,10 @@ module ODBCAdapter
       end
     end
 
+    def internal_exec_query(sql, name = 'SQL', binds = [], prepare: false) # rubocop:disable Lint/UnusedMethodArgument
+      exec_query(sql, name, binds)
+    end
+
     # Executes delete +sql+ statement in the context of this connection using
     # +binds+ as the bind substitutes. +name+ is logged along with
     # the executed +sql+ statement.

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -10,7 +10,7 @@ module ODBCAdapter
     def execute(sql, name = nil, binds = [])
       log(sql, name) do
         sql = bind_params(binds, sql) if prepared_statements
-        @connection.do(sql)
+        @raw_connection.do(sql)
       end
     end
 
@@ -27,7 +27,7 @@ module ODBCAdapter
     def internal_exec_query(sql, name = 'SQL', binds = [], prepare: false) # rubocop:disable Lint/UnusedMethodArgument
       log(sql, name) do
         sql = bind_params(binds, sql) if prepared_statements
-        stmt =  @connection.run(sql)
+        stmt =  @raw_connection.run(sql)
 
         columns = stmt.columns
         values  = stmt.to_a
@@ -49,20 +49,20 @@ module ODBCAdapter
 
     # Begins the transaction (and turns off auto-committing).
     def begin_db_transaction
-      @connection.autocommit = false
+      @raw_connection.autocommit = false
     end
 
     # Commits the transaction (and turns on auto-committing).
     def commit_db_transaction
-      @connection.commit
-      @connection.autocommit = true
+      @raw_connection.commit
+      @raw_connection.autocommit = true
     end
 
     # Rolls back the transaction (and turns on auto-committing). Must be
     # done if the transaction block raises an exception or returns false.
     def exec_rollback_db_transaction
-      @connection.rollback
-      @connection.autocommit = true
+      @raw_connection.rollback
+      @raw_connection.autocommit = true
     end
 
     # Returns the default sequence name for a table.
@@ -124,8 +124,8 @@ module ODBCAdapter
                         # so that future us can see what they should be
                         value
                       else
-                        # the use of @connection.types() results in a "was not dropped before garbage collection" warning.
-                        raise "Unknown column type: #{column.type}  #{@connection.types(column.type).first[0]}"
+                        # the use of @@raw_connection.types() results in a "was not dropped before garbage collection" warning.
+                        raise "Unknown column type: #{column.type}  #{@raw_connection.types(column.type).first[0]}"
                       end
 
           row[col_index] = new_value

--- a/lib/odbc_adapter/quoting.rb
+++ b/lib/odbc_adapter/quoting.rb
@@ -28,7 +28,7 @@ module ODBCAdapter
     # sequence, but not all ODBC drivers support them.
     def quoted_date(value)
       if value.acts_like?(:time)
-        zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
+        zone_conversion_method = ActiveRecord.default_timezone == :utc ? :getutc : :getlocal
 
         if value.respond_to?(zone_conversion_method)
           value = value.send(zone_conversion_method)

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -10,7 +10,7 @@ module ODBCAdapter
     # Returns an array of table names, for database tables visible on the
     # current connection.
     def tables(_name = nil)
-      stmt   = @connection.tables
+      stmt   = @raw_connection.tables
       result = stmt.fetch_all || []
       stmt.drop
 
@@ -31,7 +31,7 @@ module ODBCAdapter
 
     # Returns an array of indexes for the given table.
     def indexes(table_name, _name = nil)
-      stmt   = @connection.indexes(native_case(table_name.to_s))
+      stmt   = @raw_connection.indexes(native_case(table_name.to_s))
       result = stmt.fetch_all || []
       stmt.drop unless stmt.nil?
 
@@ -134,7 +134,7 @@ module ODBCAdapter
 
     # Returns just a table's primary key
     def primary_key(table_name)
-      stmt   = @connection.primary_keys(native_case(table_name.to_s))
+      stmt   = @raw_connection.primary_keys(native_case(table_name.to_s))
       result = stmt.fetch_all || []
       stmt.drop unless stmt.nil?
 
@@ -144,7 +144,7 @@ module ODBCAdapter
     end
 
     def foreign_keys(table_name)
-      stmt   = @connection.foreign_keys(native_case(table_name.to_s))
+      stmt   = @raw_connection.foreign_keys(native_case(table_name.to_s))
       result = stmt.fetch_all || []
       stmt.drop unless stmt.nil?
 

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -78,7 +78,8 @@ module ODBCAdapter
           col_native_type: extract_data_type_from_snowflake(data_type_parsed["type"]),
           column_size: extract_column_size_from_snowflake(data_type_parsed),
           numeric_scale: extract_scale_from_snowflake(data_type_parsed),
-          is_nullable: data_type_parsed["nullable"]
+          is_nullable: data_type_parsed["nullable"],
+          auto_incremented: query_result["autoincrement"] != ""
         }
       end
 
@@ -99,6 +100,7 @@ module ODBCAdapter
         col_limit       = col[:column_size]
         col_scale       = col[:numeric_scale]
         col_nullable    = col[:is_nullable]
+        auto_incremented = col[:auto_incremented]
 
         args = { sql_type: construct_sql_type(col_native_type, col_limit, col_scale), type: col_native_type, limit: col_limit }
         args[:type] = case col_native_type
@@ -126,7 +128,7 @@ module ODBCAdapter
 
         sql_type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(**args)
 
-        cols << new_column(format_case(col_name), col_default, sql_type_metadata, col_nullable, col_native_type)
+        cols << new_column(format_case(col_name), col_default, sql_type_metadata, col_nullable, col_native_type, auto_incremented)
       end
     end
 

--- a/lib/odbc_adapter/type/variant.rb
+++ b/lib/odbc_adapter/type/variant.rb
@@ -2,6 +2,10 @@ module ODBCAdapter
   module Type
     class Variant < ActiveRecord::Type::Value
 
+      def type
+        :variant
+      end
+
       def deserialize(value)
         # deserialize can contain the results of the previous serialize, rather than the database returned value
         if value.is_a? SnowflakeVariant then return value.internal_data end

--- a/odbc_adapter.gemspec
+++ b/odbc_adapter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '>= 5.0.1'
+  spec.add_dependency 'activerecord', '>= 7.1.2'
   spec.add_dependency 'odbc-ruby', '~> 1.0.1'
 
   spec.add_development_dependency 'bundler', '>= 1.14'


### PR DESCRIPTION
Updates the adapter to handle Rails version 7.1.2

**lib/active_record/connection_adapters/odbc_adapter.rb**
ActiveRecord was not correctly assigning the instance variable. Manually assigning it here.

**lib/odbc_adapter/database_statements.rb**
This method was being called by active record, but did not exist in this adapter, adding it to copy functionality from other adapters

**lib/odbc_adapter/quoting.rb**
This method was moved

**odbc_adapter.gemspec**
Upgrading to use new version of ActiveRecord