### PR TITLE
APP-3419 plan years bug after rails upgrade

### DIFF
--- a/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
+++ b/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
@@ -39,12 +39,13 @@ module ODBCAdapter
           end
           temp_options = options.merge(validate: false)
           first_call_result = base_function.call(**temp_options, &block)
-          return false if first_call_result == false
-          if stripped_attributes.any?
+          if first_call_result == false
+            false
+          elsif stripped_attributes.any?
             restore_stripped_attributes(stripped_attributes)
-            return base_function.call(**options, &block)
+            base_function.call(**options, &block)
           else
-            return first_call_result
+            first_call_result
           end
         end
       end


### PR DESCRIPTION
The PlanYear tests were failing with deprecation warnings after I added the InsertAttributeStripper to them

There's a frustrating (to the whole rails community) issue with rails, the ruby TImeout library, and how it and return, throw, and catch interact which means for the moment return statements inside of transaction blocks are recommended against and will probably start throwing errors in production environments in the next rails version. They're currently throwing deprecation warnings which are causing tests to fail. This removes the return statements and restructures the InsertAttributeStripper to return the correct value without them.