### PR TITLE
[APP-3305] Use auto_populated? for Column models initialized from Postgres

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -175,7 +175,9 @@ module ActiveRecord
 
       # odbc_adapter does not support returning, so there are no return values from an insert
       def return_value_after_insert?(column) # :nodoc:
-        column.auto_incremented
+        # If the column is an ODBC Adapter column then we can use the auto_incremented flag
+        # otherwise, fallback to the default_function
+        column.is_a?(::ODBCAdapter::Column) ? column.auto_incremented : column.auto_populated?
       end
 
       class << self


### PR DESCRIPTION
If a return value should be provided after insert we need to call `auto_populated?` (the same method used in the default Column implementation) when dealing with a Column object that isn't the ODBC Adapter's version.

This can occur when a model is initialized using Postgres but then that model is needed to write into Snowflake.

When a model is initialized from Postgres the Column objects that are created are all an instance of **PostgreSQL::Column**. When they are initialized from Snowflake they are an **ODBCAdapter::Column**.

The Active Record Abstract Adapter (activerecord/lib/active_record/connection_adapters/abstract_adapter.rb) defines the `return_value_after_insert?` as:
```
def return_value_after_insert?(column) # :nodoc:
  column.auto_populated?
end
```

and the default **ConnectionAdapters::Column** defines `auto_populated?` as:
```
def auto_populated?
  auto_incremented_by_db? || default_function
end
```

**PostgreSQL::Column** defines the auto_incremeted_by_db? method as:
```
def auto_incremented_by_db?
  serial? || identity?
end
```

Because we initialize the _Blob_ and _Attachment_ ActiveStorage objects from Postgres we end up with a PostgreSQL::Column for the columns in those tables.

An example of Attachment  is:
```
#<ActiveRecord::ConnectionAdapters::PostgreSQL::Column:0x0000aaaaefc631e0 @name="id", @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0x0000aaaaef7062b0 @sql_type="bigint", @type=:integer, @limit=8, @precision=nil, @scale=nil>, @null=false, @default=nil, @default_function="nextval('active_storage_blobs_id_seq'::regclass)", @collation=nil, @comment=nil, @serial=true, @identity=nil, @generated="">
```

So, the sequence of calls would end up: `ODBC adapter -> auto_populated? -> serial?` which will return **true** because the _id_ column for Attachment is marked **@serial=true**. This means that attaching a blob to a model that exists only in Snowflake will work properly after this change because the code will not attempt to call `column.auto_incremented` on the PostgreSQL::Column instance (which doesn't support that method).