### PR TITLE
[APP-3470] Initialize known views to support checking for existence

### DIFF
--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -26,7 +26,14 @@ module ODBCAdapter
 
     # Returns an array of view names defined in the database.
     def views
-      []
+      views_query = "SHOW VIEWS IN SCHEMA #{current_schema}"
+
+      # Temporarily disable debug logging
+      query_results = ActiveRecord::Base.logger.silence do
+        exec_query(views_query)
+      end
+
+      query_results.map { |query_result| format_case(query_result["name"]) }
     end
 
     # Returns an array of indexes for the given table.


### PR DESCRIPTION
As part of the work for supporting syncing of activations from production to non-production environments we need to pull the category and minor category tables. The production version of these tables will be accessible as views in the non-production environments and the service needs to be able to determine if the views exist.

This PR adds a proper implementation of `views`, initializing the available views from Snowflake and allowing the `view_exists?` method to actually work on the odbc adapter