### PR TITLE
[APP-3470] protect against missing schema

### DIFF
--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -26,11 +26,15 @@ module ODBCAdapter
 
     # Returns an array of view names defined in the database.
     def views
-      views_query = "SHOW VIEWS IN SCHEMA #{current_schema}"
+      views_query = "SHOW VIEWS IN SCHEMA #{current_database}.#{current_schema}"
 
       # Temporarily disable debug logging
       query_results = ActiveRecord::Base.logger.silence do
-        exec_query(views_query)
+        begin
+          exec_query(views_query)
+        rescue ODBC_UTF8::Error
+          []
+        end
       end
 
       query_results.map { |query_result| format_case(query_result["name"]) }


### PR DESCRIPTION
Guard against missing schema when querying for the views.

There was an issue running the CI tests for Springbuk after using the new adapter created in [PR](https://github.com/springbuk/odbc_adapter/pull/37). It appears that the schema may not exist in CI at the time a query for the views is performed. This change will protect against that.

I made a change to my branch of Springbuk to use the specific commit with the odbc adapter changes that guard against the missing schema (ref: "9d354792df6264468719ac510fdcbdab5544d34b") and it finally passed the CI tests