### PR TITLE
[APP-3659] Add Support for Fetching Credentials from AWS

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.7
   Exclude:
   - 'vendor/**/*'
 

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -161,13 +161,10 @@ module ActiveRecord
       # new connection with the database.
       def reconnect
         disconnect!
-        # odbc_module = @config[:encoding] == 'utf8' ? ODBC_UTF8 : ODBC
         @raw_connection =
           if @config.key?(:dsn)
-            # odbc_module.connect(@config[:dsn], @config[:username], @config[:password])
             odbc_dsn_connection(@config)[0]
           else
-            # odbc_module::Database.new.drvconnect(@config[:driver])
             odbc_conn_str_connection(@config)[0]
           end
         configure_time_options(@raw_connection)

--- a/lib/aws_secrets_manager.rb
+++ b/lib/aws_secrets_manager.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'aws-sdk-secretsmanager'
+
+class AwsSecretsManager
+  @@cache_lock = Mutex.new
+  KEY_FILE_LOCAL_NAME = 'aws_snowflake.pem'.freeze
+
+  class << self
+    def configure_driver(driver, aws_secret_id)
+      retrieve_key_file(aws_secret_id)
+
+      driver.attrs['PRIV_KEY_FILE'] = Rails.root.join(AwsSecretsManager::KEY_FILE_LOCAL_NAME).to_s
+    end
+
+    def refresh_key_file(aws_secret_id)
+      retrieve_key_file(aws_secret_id, force: true)
+    end
+
+    private
+
+    def retrieve_key_file(aws_secret_id, force: false)
+      # return if Rails.env.development?
+
+      # Avoid multiple workers atempting to fetch the same key file password from the AWS Secrets Manager
+      @@cache_lock.synchronize do
+        if force || !File.exist?(Rails.root.join(KEY_FILE_LOCAL_NAME).to_s)
+          file_contents = fetch_aws_secret(aws_secret_id, force: force)
+          # Write to the file even if the contents are blank to ensure we don't keep trying to fetch the key file unless another forced attempt is made
+          File.write(Rails.root.join(KEY_FILE_LOCAL_NAME).to_s, file_contents)
+        end
+      end
+    end
+
+    def fetch_aws_secret(aws_secret_id, force: false)
+      # Rails.logger.debug "Refreshing AWS key file (id: #{aws_secret_id}, force: #{force}, region: #{ENV.fetch("AWS_REGION", nil)})"
+      puts "Refreshing AWS key file (id: #{aws_secret_id}, force: #{force}, region: #{ENV.fetch("AWS_REGION", nil)})"
+
+      aws_exceptions = [Aws::SecretsManager::Errors::AccessDeniedException, Aws::SecretsManager::Errors::DecryptionFailure,
+                        Aws::SecretsManager::Errors::InternalServiceError, Aws::SecretsManager::Errors::InvalidParameterException,
+                        Aws::SecretsManager::Errors::InvalidRequestException, Aws::SecretsManager::Errors::ResourceNotFoundException]
+
+      client = Aws::SecretsManager::Client.new(region: ENV.fetch("AWS_REGION", nil))
+      begin
+        secret_value_response = client.get_secret_value(secret_id: aws_secret_id)
+      rescue Seahorse::Client::NetworkingError => e
+        # occurs when client cannot connect to AWS, possibly a bad region
+        puts "=====> Error retrieving AWS key file from Secrets Manager: #{e.message}"
+        raise
+      rescue *aws_exceptions => e
+        # occurs when secret_id is not found or user does not have permission to access it
+        puts "=====> Error retrieving AWS key file from Secrets Manager: #{e.message}"
+        raise
+      else
+        secret_value_response.secret_string
+      end
+    end
+  end
+end

--- a/lib/aws_secrets_manager.rb
+++ b/lib/aws_secrets_manager.rb
@@ -22,8 +22,6 @@ class AwsSecretsManager
     private
 
     def retrieve_key_file(aws_secret_id, force: false)
-      # return if Rails.env.development?
-
       # Avoid multiple workers atempting to fetch the same key file password from the AWS Secrets Manager
       @@cache_lock.synchronize do
         if force || !File.exist?(Rails.root.join(KEY_FILE_LOCAL_NAME).to_s)

--- a/lib/aws_secrets_manager.rb
+++ b/lib/aws_secrets_manager.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
+
 require 'aws-sdk-secretsmanager'
 
 class AwsSecretsManager
   @@cache_lock = Mutex.new
-  KEY_FILE_LOCAL_NAME = 'aws_snowflake.pem'.freeze
+  KEY_FILE_LOCAL_NAME = 'aws_snowflake.pem'
 
   class AwsError < StandardError
   end

--- a/lib/aws_secrets_manager.rb
+++ b/lib/aws_secrets_manager.rb
@@ -5,6 +5,9 @@ class AwsSecretsManager
   @@cache_lock = Mutex.new
   KEY_FILE_LOCAL_NAME = 'aws_snowflake.pem'.freeze
 
+  class AwsError < StandardError
+  end
+
   class << self
     def configure_driver(driver, aws_secret_id)
       retrieve_key_file(aws_secret_id)
@@ -24,32 +27,34 @@ class AwsSecretsManager
       # Avoid multiple workers atempting to fetch the same key file password from the AWS Secrets Manager
       @@cache_lock.synchronize do
         if force || !File.exist?(Rails.root.join(KEY_FILE_LOCAL_NAME).to_s)
-          file_contents = fetch_aws_secret(aws_secret_id, force: force)
-          # Write to the file even if the contents are blank to ensure we don't keep trying to fetch the key file unless another forced attempt is made
+          Rails.logger.info "AwsSecretsManager: Database key file #{force ? 'forced refresh' : 'not found'}, fetching from AWS"
+
+          file_contents = fetch_aws_secret(aws_secret_id)
           File.write(Rails.root.join(KEY_FILE_LOCAL_NAME).to_s, file_contents)
         end
       end
     end
 
-    def fetch_aws_secret(aws_secret_id, force: false)
-      # Rails.logger.debug "Refreshing AWS key file (id: #{aws_secret_id}, force: #{force}, region: #{ENV.fetch("AWS_REGION", nil)})"
-      puts "Refreshing AWS key file (id: #{aws_secret_id}, force: #{force}, region: #{ENV.fetch("AWS_REGION", nil)})"
+    def fetch_aws_secret(aws_secret_id)
+      Rails.logger.debug "AwsSecretsManager: Retrieving AWS key file (id: #{aws_secret_id}, region: #{ENV.fetch('AWS_REGION', nil)})"
 
-      aws_exceptions = [Aws::SecretsManager::Errors::AccessDeniedException, Aws::SecretsManager::Errors::DecryptionFailure,
-                        Aws::SecretsManager::Errors::InternalServiceError, Aws::SecretsManager::Errors::InvalidParameterException,
-                        Aws::SecretsManager::Errors::InvalidRequestException, Aws::SecretsManager::Errors::ResourceNotFoundException]
+      # Handle all general AWS Secrets Manager exceptions. NOTE: AccessDeniedException isn't part of this collection and must be handled separately
+      secret_exceptions = Aws::SecretsManager::Errors.constants.map do |e|
+        Aws::SecretsManager::Errors.const_get(e)
+      end.select { |e| e.is_a?(Class) && e < Exception }
 
-      client = Aws::SecretsManager::Client.new(region: ENV.fetch("AWS_REGION", nil))
+      client = Aws::SecretsManager::Client.new(region: ENV.fetch('AWS_REGION', nil))
       begin
         secret_value_response = client.get_secret_value(secret_id: aws_secret_id)
       rescue Seahorse::Client::NetworkingError => e
-        # occurs when client cannot connect to AWS, possibly a bad region
-        puts "=====> Error retrieving AWS key file from Secrets Manager: #{e.message}"
-        raise
-      rescue *aws_exceptions => e
-        # occurs when secret_id is not found or user does not have permission to access it
-        puts "=====> Error retrieving AWS key file from Secrets Manager: #{e.message}"
-        raise
+        # Client cannot connect to AWS, possibly a bad region
+        raise AwsError, e.message
+      rescue Aws::SecretsManager::Errors::AccessDeniedException => e
+        # User does not have permission to execute get_secret_value on the specified secret, most likely an incorrect secret_id
+        raise AwsError, e.message
+      rescue *secret_exceptions => e
+        # All general AWS Secrets Manager exceptions
+        raise AwsError, e.message
       else
         secret_value_response.secret_string
       end

--- a/lib/odbc_adapter/connect_common.rb
+++ b/lib/odbc_adapter/connect_common.rb
@@ -48,7 +48,7 @@ module ODBCAdapter
           # If the connection string specifies an AWS secret key id as the value of PRIV_KEY_FILE (instead of a filepath as used in development environments)
           # then attempt to fetch the latest private key file from AWS, serialize it and attempt to connect again. Local files are identified by a value starting with Rails.root
           # (such as '/path/to/private_key.pem')
-          raise unless aws_secret_id && e.message.include?('private key')
+          raise unless aws_secret_id && (e.message.include?('private key') || e.message.include?('JWT token'))
 
           begin
             AwsSecretsManager.refresh_key_file(aws_secret_id)

--- a/lib/odbc_adapter/connect_common.rb
+++ b/lib/odbc_adapter/connect_common.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'odbc'
+require 'odbc_utf8'
+require 'aws_secrets_manager'
+
+module ODBCAdapter
+  # Common support for establishing a connection or reconnecting to a database.
+  class ConnectCommon
+    class << self
+      # Connect using a predefined DSN.
+      def odbc_dsn_connection(config)
+        username   = config[:username]&.to_s
+        password   = config[:password]&.to_s
+        odbc_module = config[:encoding] == 'utf8' ? ODBC_UTF8 : ODBC
+        connection = odbc_module.connect(config[:dsn], username, password)
+
+        # encoding_bug indicates that the driver is using non ASCII and has the issue referenced here https://github.com/larskanis/ruby-odbc/issues/2
+        [connection, config.merge(username: username, password: password, encoding_bug: config[:encoding] == 'utf8')]
+      end
+
+      # Connect using an ODBC connection string.
+      # Supports DSN-based or DSN-less connections
+      # e.g. "DSN=virt5;UID=rails;PWD=rails"
+      #      "DRIVER={OpenLink Virtuoso};HOST=carlmbp;UID=rails;PWD=rails"
+      def odbc_conn_str_connection(config)
+        attrs = config[:conn_str].split(';').map { |option| option.split('=', 2) }.to_h
+        odbc_module = attrs['ENCODING'] == 'utf8' ? ODBC_UTF8 : ODBC
+
+        # The connection string may specify an AWS secret key id as the value of PRIV_KEY_FILE. Development environmnets typically just use a filepath of a static key file.
+        aws_secret_id = attrs['PRIV_KEY_FILE']&.start_with?(Rails.root.to_s) ? nil : attrs['PRIV_KEY_FILE']
+
+        # when called from reconnect a driver may already be defined
+        driver = config[:driver] || odbc_module::Driver.new
+
+        if config[:driver]
+          Rails.logger.info "odbc_adapter: Reconnecting using existing driver (#{driver.name})"
+        else
+          driver.name = 'odbc'
+          driver.attrs = attrs
+          AwsSecretsManager.configure_driver(driver, aws_secret_id) if aws_secret_id
+        end
+
+        begin
+          Rails.logger.debug "odbc_adapter: Connecting with key file: #{driver.attrs['PRIV_KEY_FILE']}"
+          connection = odbc_module::Database.new.drvconnect(driver)
+        rescue odbc_module::Error => e
+          # If the connection string specifies an AWS secret key id as the value of PRIV_KEY_FILE (instead of a filepath as used in development environments)
+          # then attempt to fetch the latest private key file from AWS, serialize it and attempt to connect again. Local files are identified by a value starting with Rails.root
+          # (such as '/path/to/private_key.pem')
+          raise unless aws_secret_id && e.message.include?('private key')
+
+          begin
+            AwsSecretsManager.refresh_key_file(aws_secret_id)
+          rescue AwsSecretsManager::AwsError => e
+            raise ActiveRecord::DatabaseConnectionError, "Unable to determine correct database credentials from AWS secret: #{e.message}"
+          else
+            Rails.logger.info 'odbc_adapter: Attempting reconnect after refresh of key file'
+            connection = odbc_module::Database.new.drvconnect(driver)
+          end
+        end
+
+        # encoding_bug indicates that the driver is using non ASCII and has the issue referenced here https://github.com/larskanis/ruby-odbc/issues/2
+        [connection, config.merge(driver: driver, encoding: attrs['ENCODING'], encoding_bug: attrs['ENCODING'] == 'utf8')]
+      end
+    end
+  end
+end

--- a/lib/odbc_adapter/connect_common.rb
+++ b/lib/odbc_adapter/connect_common.rb
@@ -55,7 +55,7 @@ module ODBCAdapter
           rescue AwsSecretsManager::AwsError => e
             raise ActiveRecord::DatabaseConnectionError, "Unable to determine correct database credentials from AWS secret: #{e.message}"
           else
-            Rails.logger.info 'odbc_adapter: Attempting reconnect after refresh of key file'
+            Rails.logger.warn 'odbc_adapter: Attempting reconnect after refresh of key file'
             connection = odbc_module::Database.new.drvconnect(driver)
           end
         end

--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -1,3 +1,3 @@
 module ODBCAdapter
-  VERSION = '5.0.8'.freeze
+  VERSION = '5.0.9'.freeze
 end

--- a/odbc_adapter.gemspec
+++ b/odbc_adapter.gemspec
@@ -20,12 +20,13 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activerecord', '>= 7.1.2'
+  spec.add_dependency 'aws-sdk-secretsmanager'
   spec.add_dependency 'odbc-ruby', '~> 1.0.1'
 
   spec.add_development_dependency 'bundler', '>= 1.14'
   spec.add_development_dependency 'minitest', '~> 5.10'
+  spec.add_development_dependency 'pry', '~> 0.11.1'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rubocop', '0.48.1'
   spec.add_development_dependency 'simplecov', '~> 0.14'
-  spec.add_development_dependency 'pry', '~> 0.11.1'
 end


### PR DESCRIPTION
### Solution/Implementation Notes
This version of the ODBC adapter adds a new feature that allows it to attempt to repair invalid credentials when a PEM file is used to connect to Snowflake.

Snowflake connections support using a PEM file through the use of two connection attributes: PRIV_KEY_FILE & PRIV_KEY_FILE_PWD. These values have typically been used in local development environments where each developer has their own unique set of connection credentials. With this new release the connection string may specify an AWS secret key id as the value of PRIV_KEY_FILE instead of a filepath to the PEM file.

For example, in development environments the following values are typically used:
```
PRIV_KEY_FILE=<%= Rails.root.join(ENV['SF_KEY_FILE'].to_s) %>
PRIV_KEY_FILE_PWD=<%= ENV['SF_KEY_FILE_PWD'].to_s %>
```
With this new release it's now possible to specify the following:
```
PRIV_KEY_FILE=snowflake_key_rotation
PRIV_KEY_FILE_PWD=<%= ENV['SF_KEY_FILE_PWD'].to_s %>
```
which instructs the ODBC driver to:
1. Look for a PEM file named `aws_snowflake.pem` in Rails.root.
2. If not found, construct an `aws_snowflake.pem` file by pulling the contents for the file from the AWS secret key named `snowflake_key_rotation` and proceed with a connection.
3. Upon any connection failure, refresh `aws_snowflake.pem` by pulling the _latest_ contents for the file from the AWS secret key named `snowflake_key_rotation` and make 1 additional connection attempt (in case the connection problem was due to a new PEM being issued by devops for security reasons).

> [!NOTE]
> * Unless an AWS secret identifier is specified in the SF_KEY_FILE attribute the ODBC driver will behave the way it always has and will attempt to use the local PEM file without contacting AWS.
> * To prevent an endless cycle of refresh + reconnect for each worker only 1 additional connection attempt is made after refreshing the PEM before the connection is considered to have failed and an _ActiveRecord::DatabaseConnectionError_ is issued.

> [!WARNING]
> * If a new password is required to access a new PEM that is deployed to AWS then the environment variable must be updated in each container that is using the dynamic connection credentials

The `reconnect` method in the ODBC driver now uses the same methods as `odbc_connection` to ensure that the AWS behaviors are consistent when attempting to establish any connection

### Testing/QA Notes
Testing the new driver locally can be accomplished by checking out the odbc_driver code and updating the Gemfile in Springbuk or Edison to use the local repository. Once the local driver is in-use there are two additional steps necessary to use an AWS secret as part of the Snowflake connection:
- Navigate to https://us-east-1.console.aws.amazon.com/secretsmanager/secret?name=snowflake_key_rotation&region=us-east-1#
  - click the [Retrieve Secret Value] button
  - edit & replace the Plaintext secret with the contents from your own `snowflake.pem` file used in your local environment.
- Update the database.yml file and alter the connection string for one or more of the connections, replacing the value of PRIV_KEY_FILE with `PRIV_KEY_FILE=snowflake_key_rotation`
- Restart your docker container and use the application as normal
_When the container restarts it should create an aws_snowflake.pem file in the Rails root of your docker container_

> [!WARNING]
> * The `snowflake_key_rotation` secret is shared among everyone in development, so coordination will be required if two testers are attempting to use their own personal PEM key in this secret for testing this PR.

### Merge Notes
The `snowflake_key_rotation` secret was added to support testing during development of this new feature. **Coordinate with devops (John) to have this secret removed when the PR is released**