### PR TITLE
[APP-3728] Attempt re auth when token expires

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -58,6 +58,8 @@ module ActiveRecord
       ERR_QUERY_TIMED_OUT_MESSAGE                 = /Query has timed out/
       ERR_CONNECTION_FAILED_REGEX                 = '^08[0S]0[12347]'.freeze
       ERR_CONNECTION_FAILED_MESSAGE               = /Client connection failed/
+      ERR_CONNECTION_UNAUTHENTICATED_MESSAGE      = /Authentication token has expired\.  The user must authenticate again\./
+      ERR_SESSION_TIMOUT = /Session no longer exists\. New login required to access the service\./
 
       # The object that stores the information that is fetched from the DBMS
       # when a connection is first established.
@@ -198,6 +200,10 @@ module ActiveRecord
           rescue => e
             puts "unable to reconnect #{e}"
           end
+        elsif exception.message.match(ERR_CONNECTION_UNAUTHENTICATED_MESSAGE) || exception.message.match(ERR_SESSION_TIMOUT)
+          Rails.logger.warn 'ODBCAdapter: Authentication token has expired. Attempting to reconnect.'
+          reconnect!
+          @raw_connection.run(sql)
         else
           super
         end

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -53,12 +53,12 @@ module ActiveRecord
       DATE_TYPE = 'DATE'.freeze
       JSON_TYPE = 'JSON'.freeze
 
-      ERR_DUPLICATE_KEY_VALUE                     = 23_505
-      ERR_QUERY_TIMED_OUT                         = 57_014
-      ERR_QUERY_TIMED_OUT_MESSAGE                 = /Query has timed out/
-      ERR_CONNECTION_FAILED_REGEX                 = '^08[0S]0[12347]'.freeze
-      ERR_CONNECTION_FAILED_MESSAGE               = /Client connection failed/
-      ERR_CONNECTION_UNAUTHENTICATED_MESSAGE      = /Authentication token has expired\.  The user must authenticate again\./
+      # ERR_DUPLICATE_KEY_VALUE                     = 23_505
+      # ERR_QUERY_TIMED_OUT                         = 57_014
+      # ERR_QUERY_TIMED_OUT_MESSAGE                 = /Query has timed out/
+      # ERR_CONNECTION_FAILED_REGEX                 = '^08[0S]0[12347]'.freeze
+      # ERR_CONNECTION_FAILED_MESSAGE               = /Client connection failed/
+      ERR_CONNECTION_UNAUTHENTICATED_MESSAGE = /Authentication token has expired\.  The user must authenticate again\./
       ERR_SESSION_TIMOUT = /Session no longer exists\. New login required to access the service\./
 
       # The object that stores the information that is fetched from the DBMS
@@ -186,29 +186,29 @@ module ActiveRecord
 
       # Translate an exception from the native DBMS to something usable by
       # ActiveRecord.
-      def translate_exception(exception, message:, sql:, binds:)
-        error_number = exception.message[/^\d+/].to_i
-        Rails.logger.debug 'ODBCAdapter: hit translate_exception with message #{exception.message}' 
+      # def translate_exception(exception, message:, sql:, binds:)
+      #   error_number = exception.message[/^\d+/].to_i
+      #   Rails.logger.debug 'ODBCAdapter: hit translate_exception with message #{exception.message}' 
 
-        if error_number == ERR_DUPLICATE_KEY_VALUE
-          ActiveRecord::RecordNotUnique.new(message, sql: sql, binds: binds)
-        elsif error_number == ERR_QUERY_TIMED_OUT || exception.message =~ ERR_QUERY_TIMED_OUT_MESSAGE
-          ::ODBCAdapter::QueryTimeoutError.new(message, sql: sql, binds: binds)
-        elsif exception.message.match(ERR_CONNECTION_FAILED_REGEX) || exception.message =~ ERR_CONNECTION_FAILED_MESSAGE
-          begin
-            reconnect!
-            ::ODBCAdapter::ConnectionFailedError.new(message, sql: sql, binds: binds)
-          rescue => e
-            puts "unable to reconnect #{e}"
-          end
-        elsif exception.message.match(ERR_CONNECTION_UNAUTHENTICATED_MESSAGE) || exception.message.match(ERR_SESSION_TIMOUT)
-          Rails.logger.warn 'ODBCAdapter: Authentication token has expired. Attempting to reconnect.'
-          reconnect!
-          @raw_connection.run(sql)
-        else
-          super
-        end
-      end
+      #   if error_number == ERR_DUPLICATE_KEY_VALUE
+      #     ActiveRecord::RecordNotUnique.new(message, sql: sql, binds: binds)
+      #   elsif error_number == ERR_QUERY_TIMED_OUT || exception.message =~ ERR_QUERY_TIMED_OUT_MESSAGE
+      #     ::ODBCAdapter::QueryTimeoutError.new(message, sql: sql, binds: binds)
+      #   elsif exception.message.match(ERR_CONNECTION_FAILED_REGEX) || exception.message =~ ERR_CONNECTION_FAILED_MESSAGE
+      #     begin
+      #       reconnect!
+      #       ::ODBCAdapter::ConnectionFailedError.new(message, sql: sql, binds: binds)
+      #     rescue => e
+      #       puts "unable to reconnect #{e}"
+      #     end
+      #   elsif exception.message.match(ERR_CONNECTION_UNAUTHENTICATED_MESSAGE) || exception.message.match(ERR_SESSION_TIMOUT)
+      #     Rails.logger.warn 'ODBCAdapter: Authentication token has expired. Attempting to reconnect.'
+      #     reconnect!
+      #     @raw_connection.run(sql)
+      #   else
+      #     super
+      #   end
+      # end
 
       private
 

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -188,6 +188,7 @@ module ActiveRecord
       # ActiveRecord.
       def translate_exception(exception, message:, sql:, binds:)
         error_number = exception.message[/^\d+/].to_i
+        Rails.logger.debug 'ODBCAdapter: hit translate_exception with message #{exception.message}' 
 
         if error_number == ERR_DUPLICATE_KEY_VALUE
           ActiveRecord::RecordNotUnique.new(message, sql: sql, binds: binds)

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -53,14 +53,6 @@ module ActiveRecord
       DATE_TYPE = 'DATE'.freeze
       JSON_TYPE = 'JSON'.freeze
 
-      # ERR_DUPLICATE_KEY_VALUE                     = 23_505
-      # ERR_QUERY_TIMED_OUT                         = 57_014
-      # ERR_QUERY_TIMED_OUT_MESSAGE                 = /Query has timed out/
-      # ERR_CONNECTION_FAILED_REGEX                 = '^08[0S]0[12347]'.freeze
-      # ERR_CONNECTION_FAILED_MESSAGE               = /Client connection failed/
-      # ERR_CONNECTION_UNAUTHENTICATED_MESSAGE = /Authentication token has expired\.  The user must authenticate again\./
-      # ERR_SESSION_TIMOUT = /Session no longer exists\. New login required to access the service\./
-
       # The object that stores the information that is fetched from the DBMS
       # when a connection is first established.
       attr_reader :database_metadata
@@ -181,34 +173,6 @@ module ActiveRecord
 
       TYPE_MAP = Type::TypeMap.new.tap { |m| initialize_type_map(m) }
       EXTENDED_TYPE_MAPS = Concurrent::Map.new
-
-      protected
-
-      # Translate an exception from the native DBMS to something usable by
-      # ActiveRecord.
-      # def translate_exception(exception, message:, sql:, binds:)
-      #   error_number = exception.message[/^\d+/].to_i
-      #   Rails.logger.debug 'ODBCAdapter: hit translate_exception with message #{exception.message}' 
-
-      #   if error_number == ERR_DUPLICATE_KEY_VALUE
-      #     ActiveRecord::RecordNotUnique.new(message, sql: sql, binds: binds)
-      #   elsif error_number == ERR_QUERY_TIMED_OUT || exception.message =~ ERR_QUERY_TIMED_OUT_MESSAGE
-      #     ::ODBCAdapter::QueryTimeoutError.new(message, sql: sql, binds: binds)
-      #   elsif exception.message.match(ERR_CONNECTION_FAILED_REGEX) || exception.message =~ ERR_CONNECTION_FAILED_MESSAGE
-      #     begin
-      #       reconnect!
-      #       ::ODBCAdapter::ConnectionFailedError.new(message, sql: sql, binds: binds)
-      #     rescue => e
-      #       puts "unable to reconnect #{e}"
-      #     end
-      #   elsif exception.message.match(ERR_CONNECTION_UNAUTHENTICATED_MESSAGE) || exception.message.match(ERR_SESSION_TIMOUT)
-      #     Rails.logger.warn 'ODBCAdapter: Authentication token has expired. Attempting to reconnect.'
-      #     reconnect!
-      #     @raw_connection.run(sql)
-      #   else
-      #     super
-      #   end
-      # end
 
       private
 

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -58,8 +58,8 @@ module ActiveRecord
       # ERR_QUERY_TIMED_OUT_MESSAGE                 = /Query has timed out/
       # ERR_CONNECTION_FAILED_REGEX                 = '^08[0S]0[12347]'.freeze
       # ERR_CONNECTION_FAILED_MESSAGE               = /Client connection failed/
-      ERR_CONNECTION_UNAUTHENTICATED_MESSAGE = /Authentication token has expired\.  The user must authenticate again\./
-      ERR_SESSION_TIMOUT = /Session no longer exists\. New login required to access the service\./
+      # ERR_CONNECTION_UNAUTHENTICATED_MESSAGE = /Authentication token has expired\.  The user must authenticate again\./
+      # ERR_SESSION_TIMOUT = /Session no longer exists\. New login required to access the service\./
 
       # The object that stores the information that is fetched from the DBMS
       # when a connection is first established.

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -40,10 +40,9 @@ module ODBCAdapter
         begin
           stmt =  @raw_connection.run(sql)
         rescue odbc_module::Error => e
-          Rails.logger.debug "ODBCAdapter: Rescued odbc_module error - #{e.message}"
-        rescue StandardError => e
-          Rails.logger.debug "ODBCAdapter: Rescued StandardError - #{e.message}"
-          if e.message.match(ERR_CONNECTION_UNAUTHENTICATED_MESSAGE) || e.message.match(ERR_SESSION_TIMOUT)
+          Rails.logger.debug "ODBCAdapter: Rescued odbc_module cause - #{e.cause}"
+          Rails.logger.debug "ODBCAdapter: Rescued odbc_module cause.message - #{e.cause.message}"
+          if e.cause.message.match(ERR_CONNECTION_UNAUTHENTICATED_MESSAGE) || e.cause.message.match(ERR_SESSION_TIMOUT)
             Rails.logger.warn 'ODBCAdapter: Session or authentication has expired. Attempting to reconnect.'
             reconnect!
             stmt = @raw_connection.run(sql)

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -39,9 +39,10 @@ module ODBCAdapter
 
         begin
           stmt =  @raw_connection.run(sql)
-        # rescue odbc_module::Error => e
+        rescue odbc_module::Error => e
+          Rails.logger.debug "ODBCAdapter: Rescued odbc_module error - #{e.message}"
         rescue StandardError => e
-          Rails.logger.debug "ODBCAdapter: Rescued error - #{e}"
+          Rails.logger.debug "ODBCAdapter: Rescued StandardError - #{e.message}"
           if e.message.match(ERR_CONNECTION_UNAUTHENTICATED_MESSAGE) || e.message.match(ERR_SESSION_TIMOUT)
             Rails.logger.warn 'ODBCAdapter: Session or authentication has expired. Attempting to reconnect.'
             reconnect!

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -6,8 +6,8 @@ module ODBCAdapter
     SQL_NULLABLE_UNKNOWN = 2
 
     # ODBC connection error messages
-    ERR_CONNECTION_UNAUTHENTICATED_MESSAGE = /Authentication token has expired\.  The user must authenticate again\./
-    ERR_SESSION_TIMOUT = /Session no longer exists\. New login required to access the service\./
+    ERR_CONNECTION_AUTHENTICATION_EXPIRED = /Authentication token has expired\. The user must authenticate again\./
+    ERR_SESSION_NO_LONGER_EXISTS = /Session no longer exists\. New login required to access the service\./
 
     # Executes the SQL statement in the context of this connection.
     # Returns the number of rows affected.
@@ -40,9 +40,9 @@ module ODBCAdapter
         begin
           stmt =  @raw_connection.run(sql)
         rescue odbc_module::Error => e
-          Rails.logger.debug "ODBCAdapter: Rescued odbc_module cause - #{e.cause}"
-          Rails.logger.debug "ODBCAdapter: Rescued odbc_module cause.message - #{e.cause.message}"
-          if e.cause.message.match(ERR_CONNECTION_UNAUTHENTICATED_MESSAGE) || e.cause.message.match(ERR_SESSION_TIMOUT)
+          msg = e.message.gsub(/\s+/, " ")
+
+          if msg.match(ERR_CONNECTION_AUTHENTICATION_EXPIRED) || msg.match(ERR_SESSION_NO_LONGER_EXISTS)
             Rails.logger.warn 'ODBCAdapter: Session or authentication has expired. Attempting to reconnect.'
             reconnect!
             stmt = @raw_connection.run(sql)

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -32,8 +32,8 @@ module ODBCAdapter
 
         begin
           stmt =  @raw_connection.run(sql)
-        rescue ODBCAdapter::Error => e
-          if e.message.match(ERR_CONNECTION_UNAUTHENTICATED_MESSAGE) || e.message.match(ERR_SESSION_TIMOUT)
+        rescue exception
+          if exception.message.match(ERR_CONNECTION_UNAUTHENTICATED_MESSAGE) || exception.message.match(ERR_SESSION_TIMOUT)
             Rails.logger.warn 'ODBCAdapter: Session or authentication has expired. Attempting to reconnect.'
             reconnect!
             stmt = @raw_connection.run(sql)

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -5,6 +5,10 @@ module ODBCAdapter
     SQL_NULLABLE = 1
     SQL_NULLABLE_UNKNOWN = 2
 
+    # ODBC connection error messages
+    ERR_CONNECTION_UNAUTHENTICATED_MESSAGE = /Authentication token has expired\.  The user must authenticate again\./
+    ERR_SESSION_TIMOUT = /Session no longer exists\. New login required to access the service\./
+
     # Executes the SQL statement in the context of this connection.
     # Returns the number of rows affected.
     def execute(sql, name = nil, binds = [])

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -30,6 +30,17 @@ module ODBCAdapter
       log(sql, name) do
         sql = bind_params(binds, sql) if prepared_statements
         stmt =  @raw_connection.run(sql)
+        # begin
+        #   stmt =  @raw_connection.run(sql)
+        # rescue ODBCAdapter::Error => e
+        #   if e.message.include?('Authentication token has expired.')
+        #     Rails.logger.warn 'ODBCAdapter: Authentication token has expired. Attempting to reconnect.'
+        #     reconnect!
+        #     stmt = @raw_connection.run(sql)
+        #   else
+        #     raise e
+        #   end
+        # end
 
         columns = stmt.columns
         values  = stmt.to_a

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -40,6 +40,7 @@ module ODBCAdapter
         begin
           stmt =  @raw_connection.run(sql)
         rescue odbc_module::Error => e
+          Rails.logger.debug "ODBCAdapter: Rescued error - #{e.message}"
           if e.message.match(ERR_CONNECTION_UNAUTHENTICATED_MESSAGE) || e.message.match(ERR_SESSION_TIMOUT)
             Rails.logger.warn 'ODBCAdapter: Session or authentication has expired. Attempting to reconnect.'
             reconnect!

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -29,7 +29,9 @@ module ODBCAdapter
       sql = transform_query(sql)
       log(sql, name) do
         sql = bind_params(binds, sql) if prepared_statements
+        Rails.logger.debug 'ODBCAdapter: Executing run SQL statement'
         stmt =  @raw_connection.run(sql)
+        Rails.logger.debug 'ODBCAdapter: Successfully executed run SQL statement'
         # begin
         #   stmt =  @raw_connection.run(sql)
         # rescue ODBCAdapter::Error => e

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -39,8 +39,9 @@ module ODBCAdapter
 
         begin
           stmt =  @raw_connection.run(sql)
-        rescue odbc_module::Error => e
-          Rails.logger.debug "ODBCAdapter: Rescued error - #{e.message}"
+        # rescue odbc_module::Error => e
+        rescue StandardError => e
+          Rails.logger.debug "ODBCAdapter: Rescued error - #{e}"
           if e.message.match(ERR_CONNECTION_UNAUTHENTICATED_MESSAGE) || e.message.match(ERR_SESSION_TIMOUT)
             Rails.logger.warn 'ODBCAdapter: Session or authentication has expired. Attempting to reconnect.'
             reconnect!


### PR DESCRIPTION
## Source
https://springbuk-glass.atlassian.net/browse/APP-3728

## Problem
We're running into an error on Edison that reads
```
08001 (390114) Authentication token has expired.  The user must authenticate again.
```

Modifying the ODBC internals to automatically reconnect when this error case happens should solve this.

## Solution
This change was a doozy of trial/error that led to the discovery that the `translate_exception` method is no longer (perhaps after the move from rails 6 -> 7) being called as intended.  As such, I've removed the `translate_exception` override code,  moved the error based reconnect functionality from there to the `internal_exec_query` method, and included the new error cases.  I also added functionality to rerun the failing SQL in these cases.

## Testing/QA Notes
I've deployed this change across the various SB4 repos that use the ODBC adapter.  There should be no new error messages related to connection errors.
