### PR TITLE
App 4370 upgrade rails

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="ruby-2.6.3-p62" project-jdk-type="RUBY_SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/odbc_adapter.iml" filepath="$PROJECT_DIR$/.idea/odbc_adapter.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/odbc_adapter.iml
+++ b/.idea/odbc_adapter.iml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="RUBY_MODULE" version="4">
+  <component name="ModuleRunConfigurationManager">
+    <shared />
+  </component>
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/features" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="PROVIDED" name="bundler (v1.17.2, ruby-2.6.3-p62) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="minitest (v5.11.3, ruby-2.6.3-p62) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rake (v12.3.3, ruby-2.6.3-p62) [gem]" level="application" />
+  </component>
+  <component name="RakeTasksCache">
+    <option name="myRootTask">
+      <RakeTaskImpl id="rake" />
+    </option>
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -88,11 +88,6 @@ module ActiveRecord
 
       def connect
         @raw_connection, @config, @database_metadata = self.class.new_client(@config)
-        if @config.key?(:dsn)
-          ::ODBCAdapter::ConnectCommon.odbc_dsn_connection(@config)[0]
-        else
-          ::ODBCAdapter::ConnectCommon.odbc_conn_str_connection(@config)[0]
-        end
         configure_time_options(@raw_connection)
       end
 

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -19,14 +19,6 @@ require 'odbc_adapter/concerns/concern'
 require 'odbc_adapter/connect_common'
 
 module ActiveRecord
-  class Base
-    class << self
-      # Build a new ODBC connection with the given configuration.
-      def odbc_connection(config)
-      end
-    end
-  end
-
   module ConnectionAdapters
     class ODBCAdapter < AbstractAdapter
       include ::ODBCAdapter::DatabaseLimits

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -29,6 +29,11 @@ module ActiveRecord
 
   module ConnectionAdapters
     class ODBCAdapter < AbstractAdapter
+      include ::ODBCAdapter::DatabaseLimits
+      include ::ODBCAdapter::DatabaseStatements
+      include ::ODBCAdapter::Quoting
+      include ::ODBCAdapter::SchemaStatements
+
       ADAPTER_NAME = 'ODBC'.freeze
       BOOLEAN_TYPE = 'BOOLEAN'.freeze
       VARIANT_TYPE = 'VARIANT'.freeze
@@ -37,7 +42,6 @@ module ActiveRecord
 
       class << self
         def new_client(config)
-          p "ODBCAdapter new_client"
           config = config.symbolize_keys
 
           connection, config =
@@ -55,17 +59,11 @@ module ActiveRecord
         end
       end
 
-      include ::ODBCAdapter::DatabaseLimits
-      include ::ODBCAdapter::DatabaseStatements
-      include ::ODBCAdapter::Quoting
-      include ::ODBCAdapter::SchemaStatements
-
       # The object that stores the information that is fetched from the DBMS
       # when a connection is first established.
       attr_reader :database_metadata
 
       def initialize(...)
-        p "ODBCAdapter initialize"
         super
 
         @raw_connection = nil
@@ -97,7 +95,6 @@ module ActiveRecord
       end
 
       def connect
-        p "Connecting to #{@config[:dsn] || @config[:conn_str]}"
         @raw_connection, @config, @database_metadata = self.class.new_client(@config)
         if @config.key?(:dsn)
           ::ODBCAdapter::ConnectCommon.odbc_dsn_connection(@config)[0]
@@ -110,7 +107,6 @@ module ActiveRecord
       # Disconnects from the database if already connected, and establishes a
       # new connection with the database.
       def reconnect
-        p "Reconnecting to #{@config[:dsn] || @config[:conn_str]}"
         disconnect!
         connect
       end

--- a/lib/odbc_adapter.rb
+++ b/lib/odbc_adapter.rb
@@ -1,3 +1,8 @@
 # Requiring with this pattern to mirror ActiveRecord
 require 'active_record/connection_adapters/odbc_adapter'
 require 'active_record/merge_all_persistence'
+
+ActiveRecord::ConnectionAdapters.register("null_odbc", "ODBCAdapter::Adapters::NullODBCAdapter", "odbc_adapter/adapters/null_odbc_adapter.rb")
+ActiveRecord::ConnectionAdapters.register("mysql_odbc", "ODBCAdapter::Adapters::MySQLODBCAdapter", "odbc_adapter/adapters/mysql_odbc_adapter.rb")
+ActiveRecord::ConnectionAdapters.register("postgresql_odbc", "ODBCAdapter::Adapters::PostgreSQLODBCAdapter", "odbc_adapter/adapters/postgresql_odbc_adapter.rb")
+ActiveRecord::ConnectionAdapters.register("snowflake_odbc", "ODBCAdapter::Adapters::SnowflakeODBCAdapter", "odbc_adapter/adapters/snowflake_odbc_adapter.rb")

--- a/lib/odbc_adapter/adapters/snowflake/database_metadata.rb
+++ b/lib/odbc_adapter/adapters/snowflake/database_metadata.rb
@@ -6,7 +6,6 @@ module ODBCAdapter
       class DatabaseMetadata < ODBCAdapter::DatabaseMetadata
         attr_reader :values
         def initialize
-          p "SnowflakeMetadata Initialize"
           @values = {
             SQL_DBMS_NAME: 'Snowflake',
             SQL_DBMS_VER: '9.27.0',

--- a/lib/odbc_adapter/adapters/snowflake/database_metadata.rb
+++ b/lib/odbc_adapter/adapters/snowflake/database_metadata.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ODBCAdapter
+  module Adapters
+    module Snowflake
+      class DatabaseMetadata < ODBCAdapter::DatabaseMetadata
+        attr_reader :values
+        def initialize
+          p "SnowflakeMetadata Initialize"
+          @values = {
+            SQL_DBMS_NAME: 'Snowflake',
+            SQL_DBMS_VER: '9.27.0',
+            SQL_IDENTIFIER_CASE: ODBC::SQL_IC_UPPER,
+            SQL_QUOTED_IDENTIFIER_CASE: 3,
+            SQL_IDENTIFIER_QUOTE_CHAR: '"',
+            SQL_MAX_IDENTIFIER_LEN: 255,
+            SQL_MAX_TABLE_NAME_LEN: 255
+          }.freeze
+        end
+      end
+    end
+  end
+
+end

--- a/lib/odbc_adapter/adapters/snowflake/schema_statements.rb
+++ b/lib/odbc_adapter/adapters/snowflake/schema_statements.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ODBCAdapter
+  module Adapters
+    module Snowflake
+      module SchemaStatements
+        def current_database
+          ActiveRecord::Base.logger.silence do
+            begin
+              exec_query('SELECT CURRENT_DATABASE() as current_database')[0]["current_database"].strip
+            rescue ODBC_UTF8::Error
+              []
+            end
+          end
+        end
+
+        def current_schema
+          ActiveRecord::Base.logger.silence do
+            begin
+              exec_query('SELECT CURRENT_SCHEMA() as current_schema')[0]["current_schema"].strip
+            rescue ODBC_UTF8::Error
+              []
+            end
+          end
+        end
+
+        def table_exists?(table_name)
+          p "In SnowflakeODBCAdapter table_exists? #{table_name}"
+          p format_case(table_name.to_s)
+          includes = tables.include?(format_case(table_name.to_s))
+          p includes
+          includes
+        end
+      end
+    end
+  end
+end

--- a/lib/odbc_adapter/adapters/snowflake/schema_statements.rb
+++ b/lib/odbc_adapter/adapters/snowflake/schema_statements.rb
@@ -25,11 +25,7 @@ module ODBCAdapter
         end
 
         def table_exists?(table_name)
-          p "In SnowflakeODBCAdapter table_exists? #{table_name}"
-          p format_case(table_name.to_s)
-          includes = tables.include?(format_case(table_name.to_s))
-          p includes
-          includes
+          tables.include?(format_case(table_name.to_s))
         end
       end
     end

--- a/lib/odbc_adapter/adapters/snowflake_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/snowflake_odbc_adapter.rb
@@ -16,7 +16,6 @@ module ODBCAdapter
 
       class << self
         def new_client(config)
-          p "SnowflakeODBCAdapter new_client"
           config = config.symbolize_keys
 
           connection, config =
@@ -42,7 +41,6 @@ module ODBCAdapter
       include ::ODBCAdapter::Adapters::Snowflake::SchemaStatements
 
       def initialize(...)
-        p "SnowflakeODBCAdapter initialize"
         super
 
         @raw_connection = nil
@@ -135,7 +133,7 @@ module ODBCAdapter
         execute("CREATE DATABASE #{quote_table_name(name)}#{option_string}")
       end
 
-      # Drops a PostgreSQL database.
+      # Drops a Snowflake database.
       #
       # Example:
       #   drop_database 'rails_development'

--- a/lib/odbc_adapter/adapters/snowflake_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/snowflake_odbc_adapter.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require 'odbc_adapter/adapters/snowflake/database_metadata'
+require 'odbc_adapter/adapters/snowflake/schema_statements'
+
+module ODBCAdapter
+  module Adapters
+    # Overrides specific to PostgreSQL. Mostly taken from
+    # ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+    class SnowflakeODBCAdapter < ActiveRecord::ConnectionAdapters::ODBCAdapter
+      BOOLEAN_TYPE = 'boolean'.freeze
+      PRIMARY_KEY  = 'SERIAL PRIMARY KEY'.freeze
+      VARIANT_TYPE = 'VARIANT'.freeze
+      DATE_TYPE = 'DATE'.freeze
+      JSON_TYPE = 'JSON'.freeze
+
+      class << self
+        def new_client(config)
+          p "SnowflakeODBCAdapter new_client"
+          config = config.symbolize_keys
+
+          connection, config =
+            if config.key?(:dsn)
+              ::ODBCAdapter::ConnectCommon.odbc_dsn_connection(config)
+            elsif config.key?(:conn_str)
+              ::ODBCAdapter::ConnectCommon.odbc_conn_str_connection(config)
+            else
+              raise ArgumentError, 'No data source name (:dsn) or connection string (:conn_str) specified.'
+            end
+
+          database_metadata = ::ODBCAdapter::Adapters::Snowflake::DatabaseMetadata.new
+
+          return connection, config, database_metadata
+        end
+
+        # Quoting needs to be changed for snowflake
+        def quote_column_name(name)
+          name.to_s
+        end
+      end
+
+      include ::ODBCAdapter::Adapters::Snowflake::SchemaStatements
+
+      def initialize(...)
+        p "SnowflakeODBCAdapter initialize"
+        super
+
+        @raw_connection = nil
+      end
+
+      def database_metadata
+        @database_metadata ||= ::ODBCAdapter::Adapters::Snowflake::DatabaseMetadata.new
+      end
+
+      alias create insert
+
+      # Override to handle booleans appropriately
+      def native_database_types
+        @native_database_types ||= super.merge(boolean: { name: 'boolean' })
+      end
+
+      def arel_visitor
+        Arel::Visitors::PostgreSQL.new(self)
+      end
+
+      # Filter for ODBCAdapter#tables
+      # Omits table from #tables if table_filter returns true
+      def table_filtered?(schema_name, table_type)
+        %w[information_schema pg_catalog].include?(schema_name) || table_type !~ /TABLE/i
+      end
+
+      def truncate(table_name, name = nil)
+        exec_query("TRUNCATE TABLE #{quote_table_name(table_name)}", name)
+      end
+
+      # Returns the sequence name for a table's primary key or some other
+      # specified key.
+      def default_sequence_name(table_name, pk = nil)
+        "#{table_name}_#{pk || 'id'}_seq"
+      end
+
+      def type_cast(value, column)
+        return super unless column
+
+        case value
+        when String
+          return super unless 'bytea' == column.native_type
+          { value: value, format: 1 }
+        else
+          super
+        end
+      end
+
+      # Quotes a string, escaping any ' (single quote) and \ (backslash)
+      # characters.
+      def quote_string(string)
+        string.gsub(/\\/, '\&\&').gsub(/'/, "''")
+      end
+
+      def disable_referential_integrity
+        execute(tables.map { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(';'))
+        yield
+      ensure
+        execute(tables.map { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(';'))
+      end
+
+      # Create a new PostgreSQL database. Options include <tt>:owner</tt>,
+      # <tt>:template</tt>, <tt>:encoding</tt>, <tt>:tablespace</tt>, and
+      # <tt>:connection_limit</tt> (note that MySQL uses <tt>:charset</tt>
+      # while PostgreSQL uses <tt>:encoding</tt>).
+      #
+      # Example:
+      #   create_database config[:database], config
+      #   create_database 'foo_development', encoding: 'unicode'
+      def create_database(name, options = {})
+        options = options.reverse_merge(encoding: 'utf8')
+
+        option_string = options.symbolize_keys.sum do |key, value|
+          case key
+          when :owner
+            " OWNER = \"#{value}\""
+          when :template
+            " TEMPLATE = \"#{value}\""
+          when :encoding
+            " ENCODING = '#{value}'"
+          when :tablespace
+            " TABLESPACE = \"#{value}\""
+          when :connection_limit
+            " CONNECTION LIMIT = #{value}"
+          else
+            ''
+          end
+        end
+
+        execute("CREATE DATABASE #{quote_table_name(name)}#{option_string}")
+      end
+
+      # Drops a PostgreSQL database.
+      #
+      # Example:
+      #   drop_database 'rails_development'
+      def drop_database(name)
+        execute "DROP DATABASE IF EXISTS #{quote_table_name(name)}"
+      end
+
+      # Renames a table.
+      def rename_table(name, new_name)
+        execute("ALTER TABLE #{quote_table_name(name)} RENAME TO #{quote_table_name(new_name)}")
+      end
+
+      def change_column(table_name, column_name, type, options = {})
+        execute("ALTER TABLE #{table_name} ALTER  #{column_name} TYPE #{type_to_sql(type, options[:limit], options[:precision], options[:scale])}")
+        change_column_default(table_name, column_name, options[:default]) if options_include_default?(options)
+      end
+
+      def change_column_default(table_name, column_name, default)
+        execute("ALTER TABLE #{table_name} ALTER COLUMN #{column_name} SET DEFAULT #{quote(default)}")
+      end
+
+      def rename_column(table_name, column_name, new_column_name)
+        execute("ALTER TABLE #{table_name} RENAME #{column_name} TO #{new_column_name}")
+      end
+
+      def remove_index!(_table_name, index_name)
+        execute("DROP INDEX #{quote_table_name(index_name)}")
+      end
+
+      def rename_index(_table_name, old_name, new_name)
+        execute("ALTER INDEX #{quote_column_name(old_name)} RENAME TO #{quote_table_name(new_name)}")
+      end
+
+      # Returns a SELECT DISTINCT clause for a given set of columns and a given
+      # ORDER BY clause.
+      #
+      # PostgreSQL requires the ORDER BY columns in the select list for
+      # distinct queries, and requires that the ORDER BY include the distinct
+      # column.
+      #
+      #   distinct("posts.id", "posts.created_at desc")
+      def distinct(columns, orders)
+        return "DISTINCT #{columns}" if orders.empty?
+
+        # Construct a clean list of column names from the ORDER BY clause,
+        # removing any ASC/DESC modifiers
+        order_columns = orders.map { |s| s.gsub(/\s+(ASC|DESC)\s*(NULLS\s+(FIRST|LAST)\s*)?/i, '') }
+        order_columns.reject!(&:blank?)
+        order_columns = order_columns.zip((0...order_columns.size).to_a).map { |s, i| "#{s} AS alias_#{i}" }
+
+        "DISTINCT #{columns}, #{order_columns * ', '}"
+      end
+
+      def default_prepared_statements
+        false
+      end
+
+      def primary_key(table_name)
+        format_case(super || "ID")
+      end
+
+    protected
+
+      # Executes an INSERT query and returns the new record's ID
+      def insert_sql(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil)
+        unless pk
+          table_ref = extract_table_ref_from_insert_sql(sql)
+          pk = primary_key(table_ref) if table_ref
+        end
+
+        if pk
+          select_value("#{sql} RETURNING #{quote_column_name(pk)}")
+        else
+          super
+        end
+      end
+
+      # Returns the current ID of a table's sequence.
+      def last_insert_id(sequence_name)
+        r = exec_query("SELECT currval('#{sequence_name}')", 'SQL')
+        Integer(r.rows.first.first)
+      end
+    end
+  end
+end

--- a/lib/odbc_adapter/adapters/snowflake_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/snowflake_odbc_adapter.rb
@@ -5,8 +5,7 @@ require 'odbc_adapter/adapters/snowflake/schema_statements'
 
 module ODBCAdapter
   module Adapters
-    # Overrides specific to PostgreSQL. Mostly taken from
-    # ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+    # Overrides specific to Snowflake. Mostly taken from
     class SnowflakeODBCAdapter < ActiveRecord::ConnectionAdapters::ODBCAdapter
       BOOLEAN_TYPE = 'boolean'.freeze
       PRIMARY_KEY  = 'SERIAL PRIMARY KEY'.freeze
@@ -96,29 +95,14 @@ module ODBCAdapter
         execute(tables.map { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(';'))
       end
 
-      # Create a new PostgreSQL database. Options include <tt>:owner</tt>,
-      # <tt>:template</tt>, <tt>:encoding</tt>, <tt>:tablespace</tt>, and
-      # <tt>:connection_limit</tt> (note that MySQL uses <tt>:charset</tt>
-      # while PostgreSQL uses <tt>:encoding</tt>).
-      #
-      # Example:
-      #   create_database config[:database], config
-      #   create_database 'foo_development', encoding: 'unicode'
-      def create_database(name, options = {})
+      # Create a new database. Options can be used to specifiy a comment.
+     def create_database(name, options = {})
         options = options.reverse_merge(encoding: 'utf8')
 
-        option_string = options.symbolize_keys.sum do |key, value|
+        option_string = options.symbolize_keys.sum("") do |key, value|
           case key
-          when :owner
-            " OWNER = \"#{value}\""
-          when :template
-            " TEMPLATE = \"#{value}\""
-          when :encoding
-            " ENCODING = '#{value}'"
-          when :tablespace
-            " TABLESPACE = \"#{value}\""
-          when :connection_limit
-            " CONNECTION LIMIT = #{value}"
+          when :comment
+            " COMMENT = #{quote(value)}"
           else
             ''
           end

--- a/lib/odbc_adapter/adapters/snowflake_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/snowflake_odbc_adapter.rb
@@ -40,12 +40,6 @@ module ODBCAdapter
 
       include ::ODBCAdapter::Adapters::Snowflake::SchemaStatements
 
-      def initialize(...)
-        super
-
-        @raw_connection = nil
-      end
-
       def database_metadata
         @database_metadata ||= ::ODBCAdapter::Adapters::Snowflake::DatabaseMetadata.new
       end

--- a/lib/odbc_adapter/connect_common.rb
+++ b/lib/odbc_adapter/connect_common.rb
@@ -48,6 +48,7 @@ module ODBCAdapter
           # If the connection string specifies an AWS secret key id as the value of PRIV_KEY_FILE (instead of a filepath as used in development environments)
           # then attempt to fetch the latest private key file from AWS, serialize it and attempt to connect again. Local files are identified by a value starting with Rails.root
           # (such as '/path/to/private_key.pem')
+          raise ActiveRecord::DatabaseConnectionError, "Unable to connect to database with driver #{driver}: #{e.message}" if aws_secret_id && (e.message.include?("json_not_object"))
           raise unless aws_secret_id && (e.message.include?('private key') || e.message.include?('JWT token'))
 
           begin

--- a/lib/odbc_adapter/database_metadata.rb
+++ b/lib/odbc_adapter/database_metadata.rb
@@ -18,9 +18,13 @@ module ODBCAdapter
     # has_encoding_bug refers to https://github.com/larskanis/ruby-odbc/issues/2 where ruby-odbc in UTF8 mode
     # returns incorrectly encoded responses to getInfo
     def initialize(connection, has_encoding_bug = false)
+      p "ODBCMetadata Initialize"
       @values = Hash[FIELDS.map do |field|
         info = connection.get_info(ODBC.const_get(field))
         info = info.encode(Encoding.default_external, 'UTF-16LE') if info.is_a?(String) && has_encoding_bug
+
+        p field
+        p info
 
         [field, info]
       end]

--- a/lib/odbc_adapter/database_metadata.rb
+++ b/lib/odbc_adapter/database_metadata.rb
@@ -18,13 +18,9 @@ module ODBCAdapter
     # has_encoding_bug refers to https://github.com/larskanis/ruby-odbc/issues/2 where ruby-odbc in UTF8 mode
     # returns incorrectly encoded responses to getInfo
     def initialize(connection, has_encoding_bug = false)
-      p "ODBCMetadata Initialize"
       @values = Hash[FIELDS.map do |field|
         info = connection.get_info(ODBC.const_get(field))
         info = info.encode(Encoding.default_external, 'UTF-16LE') if info.is_a?(String) && has_encoding_bug
-
-        p field
-        p info
 
         [field, info]
       end]

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -76,20 +76,26 @@ module ODBCAdapter
 
     # Begins the transaction (and turns off auto-committing).
     def begin_db_transaction
-      @raw_connection.autocommit = false
+      with_raw_connection do |conn|
+        conn.autocommit = false
+      end
     end
 
     # Commits the transaction (and turns on auto-committing).
     def commit_db_transaction
-      @raw_connection.commit
-      @raw_connection.autocommit = true
+      with_raw_connection do |conn|
+        conn.commit
+        conn.autocommit = true
+      end
     end
 
     # Rolls back the transaction (and turns on auto-committing). Must be
     # done if the transaction block raises an exception or returns false.
     def exec_rollback_db_transaction
-      @raw_connection.rollback
-      @raw_connection.autocommit = true
+      with_raw_connection do |conn|
+        conn.rollback
+        conn.autocommit = true
+      end
     end
 
     # Returns the default sequence name for a table.

--- a/lib/odbc_adapter/quoting.rb
+++ b/lib/odbc_adapter/quoting.rb
@@ -24,6 +24,10 @@ module ODBCAdapter
       "#{quote_char.chr}#{name}#{quote_char.chr}"
     end
 
+    def quote_table_name(table_name)
+      quote_column_name(table_name)
+    end
+
     # Ideally, we'd return an ODBC date or timestamp literal escape
     # sequence, but not all ODBC drivers support them.
     def quoted_date(value)

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -164,12 +164,15 @@ module ODBCAdapter
 
     # Returns just a table's primary key
     def primary_key(table_name)
-      stmt   = @raw_connection.primary_keys(native_case(table_name.to_s))
-      result = stmt.fetch_all || []
-      stmt.drop unless stmt.nil?
+      result = nil
+      with_raw_connection do |conn|
+        stmt   = conn.primary_keys(native_case(table_name.to_s))
+        result = stmt.fetch_all || []
+        stmt.drop unless stmt.nil?
+      end
 
       if(@config[:driver].attrs['CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX'].downcase == 'true')
-        result[0][3]
+        result[0]&.[](3)
       else
         db_regex = name_regex(current_database)
         schema_regex = name_regex(current_schema)
@@ -178,9 +181,12 @@ module ODBCAdapter
     end
 
     def foreign_keys(table_name)
-      stmt   = @raw_connection.foreign_keys(native_case(table_name.to_s))
-      result = stmt.fetch_all || []
-      stmt.drop unless stmt.nil?
+      result = nil
+      with_raw_connection do |conn|
+        stmt   = conn.foreign_keys(native_case(table_name.to_s))
+        result = stmt.fetch_all || []
+        stmt.drop unless stmt.nil?
+      end
 
       db_regex = name_regex(current_database)
       schema_regex = name_regex(current_schema)

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -17,7 +17,7 @@ module ODBCAdapter
         stmt.drop
       end
 
-      table_names = if(@config[:driver].attrs['CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX'].downcase == 'true')
+      if(@config[:driver].attrs['CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX'].downcase == 'true')
         result.each_with_object([]) do |row, table_names|
           schema_name, table_name, table_type = row[1..3]
           next if respond_to?(:table_filtered?) && table_filtered?(schema_name, table_type)
@@ -25,19 +25,14 @@ module ODBCAdapter
         end
       else
         db_regex = name_regex(current_database)
-        p db_regex
         schema_regex = name_regex(current_schema)
-        p schema_regex
-        table_names = result.each_with_object([]) do |row, table_names|
+        result.each_with_object([]) do |row, table_names|
           next unless row[0] =~ db_regex && row[1] =~ schema_regex
           schema_name, table_name, table_type = row[1..3]
           next if respond_to?(:table_filtered?) && table_filtered?(schema_name, table_type)
           table_names << format_case(table_name)
         end
       end
-
-      p table_names
-      table_names
     end
 
     # Returns an array of view names defined in the database.

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -10,23 +10,39 @@ module ODBCAdapter
     # Returns an array of table names, for database tables visible on the
     # current connection.
     def tables(_name = nil)
-      stmt   = @raw_connection.tables
-      result = stmt.fetch_all || []
-      stmt.drop
-
-      db_regex = name_regex(current_database)
-      schema_regex = name_regex(current_schema)
-      result.each_with_object([]) do |row, table_names|
-        next unless row[0] =~ db_regex && row[1] =~ schema_regex
-        schema_name, table_name, table_type = row[1..3]
-        next if respond_to?(:table_filtered?) && table_filtered?(schema_name, table_type)
-        table_names << format_case(table_name)
+      result = nil
+      with_raw_connection do |conn|
+        stmt   = conn.tables
+        result = stmt.fetch_all || []
+        stmt.drop
       end
+
+      table_names = if(@config[:driver].attrs['CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX'].downcase == 'true')
+        result.each_with_object([]) do |row, table_names|
+          schema_name, table_name, table_type = row[1..3]
+          next if respond_to?(:table_filtered?) && table_filtered?(schema_name, table_type)
+          table_names << format_case(table_name)
+        end
+      else
+        db_regex = name_regex(current_database)
+        p db_regex
+        schema_regex = name_regex(current_schema)
+        p schema_regex
+        table_names = result.each_with_object([]) do |row, table_names|
+          next unless row[0] =~ db_regex && row[1] =~ schema_regex
+          schema_name, table_name, table_type = row[1..3]
+          next if respond_to?(:table_filtered?) && table_filtered?(schema_name, table_type)
+          table_names << format_case(table_name)
+        end
+      end
+
+      p table_names
+      table_names
     end
 
     # Returns an array of view names defined in the database.
     def views
-      views_query = "SHOW VIEWS IN SCHEMA #{current_database}.#{current_schema}"
+      views_query = "SHOW VIEWS IN SCHEMA"
 
       # Temporarily disable debug logging
       query_results = ActiveRecord::Base.logger.silence do
@@ -42,9 +58,12 @@ module ODBCAdapter
 
     # Returns an array of indexes for the given table.
     def indexes(table_name, _name = nil)
-      stmt   = @raw_connection.indexes(native_case(table_name.to_s))
-      result = stmt.fetch_all || []
-      stmt.drop unless stmt.nil?
+      result = nil
+      with_raw_connection do |conn|
+        stmt   = conn.indexes(native_case(table_name.to_s))
+        result = stmt.fetch_all || []
+        stmt.drop unless stmt.nil?
+      end
 
       index_cols = []
       index_name = nil
@@ -149,9 +168,13 @@ module ODBCAdapter
       result = stmt.fetch_all || []
       stmt.drop unless stmt.nil?
 
-      db_regex = name_regex(current_database)
-      schema_regex = name_regex(current_schema)
-      result.reduce(nil) { |pkey, key| (key[0] =~ db_regex && key[1] =~ schema_regex) ? format_case(key[3]) : pkey }
+      if(@config[:driver].attrs['CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX'].downcase == 'true')
+        result[0][3]
+      else
+        db_regex = name_regex(current_database)
+        schema_regex = name_regex(current_schema)
+        result.reduce(nil) { |pkey, key| (key[0] =~ db_regex && key[1] =~ schema_regex) ? format_case(key[3]) : pkey }
+      end
     end
 
     def foreign_keys(table_name)


### PR DESCRIPTION
## Source

https://springbuk-glass.atlassian.net/browse/APP-4370

## Problem

Rails needs upgraded. The version we were on leaves support at the end of the month.

## Solution

Rails apparently is unconcerned about large breaking adapter changes on minor rails version upgrades.

Differences accounted for going from rails 7.1 to 7.2:
- The entire way in which adapters are instantiated was changed around.
  - There used to be an API requirement that said "If your adapter is named "MyAdapter" it had to pathch ActiveRecord::Base with a class/singleton method named "my_adapter_connection" that would instantiate the adapter. This is gone and adapters are now instantiated directly. Adapters are also expected to register themselves, since there's not a method for instantiating them on ActiveRecord::Base.
  - As a result of direct adapter instantiation, the method of returning a subclass of odbc_adapter is invalid. It's technically still doable, but highly inadvisable. There's an expectation that calling MyClass.new will return an instance of MyClass, not something else, and breaking that can break a lot of other things.
  - Because ODBCAdapter should not return a subclass and because adapters are required to register themselves, each ODBCAdapter subclass now individually registers itself with ActiveRecord.
    - Note: I'm certain that the other subclasses are in fact broken, but we don't use them so it'll have to wait to be a problem for the unlikely offchance that we some day used one of them.
  - Since I was messing with the individual adapter subclasses, I went ahead and made a SnowflakeODBCAdapter subclass and registered it. We will no longer be relying on a jerry rigged PostgresODBCAdapter.
- Connection establishment is now deferred.
  - Rails doesn't establish the underlying raw_connection on adapter initialization anymore, it now waits until something actually tries to interact with the database. This can save a lot of circumstances where an adapter might get instantiated because of underlying rails mechanics, but isn't ever actually used.
  - Unfortunately for us, we used that connection during initialization to determine information about the database.
  - Fortunately for us, that database information is static and since we're now registering subclasses directly I was able to hardcode the necessary information into a SnowflakeODBCAdapter::DatabaseMetadata class so we don't need to establish a connection to the database to have the relevant information.
- During the course of correcting all of the adapter connection methodology that changed to support deferred database connections, various other components that were used to get database information had to be refactored.
  - There are a bunch of places where we don't use `@raw_connection` anymore, we instead need to use `with_raw_connection` and use the provided connection so rails will establish the connection when needed.
  - The method that we were using to get the current database and schema were invalid, and this actually caused some previous bugs that I wasn't able to track down but realized this was the cause.
    - We now correctly get the current database and schema.
    - This revealed that getting the database and schema was slow and we were doing it far more often than needed when using `CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX`, which is pretty standard now. So code paths were added to check for that and bypass the calls to current_database and current_schema when we didn't need them anymore.

I'm fairly confident there's dead code in the SnowflakeODBCAdapter. I'd be amazed if anything called indexes, as snowflake doesn't really have that concept. I doubt foreign_keys is called. Hopefully we'll have time to validate these expectations and do more updates to remove these in the future when we aren't up against a deadline to successfully move rails versions.

## AI Summary

This pull request introduces support for the Snowflake database in the ODBC adapter, refactors connection management for improved reliability, and adds configuration files for JetBrains IDE integration. The main changes are grouped below:

### Snowflake Database Support

* Added a new adapter for Snowflake (`lib/odbc_adapter/adapters/snowflake_odbc_adapter.rb`), including custom schema statements and database metadata to enable ActiveRecord compatibility with Snowflake via ODBC. [[1]](diffhunk://#diff-82ef61d2a7468bdae763fb80ea442b2d42cf00f518dfff5f6b9f61e9453130c5R1-R221) [[2]](diffhunk://#diff-7e7f20204ee2a502aab3749ecfc08314eb153faa8370f82844f323f6f8928891R1-R33) [[3]](diffhunk://#diff-8210e2bc69972b1bd9edbf981b1489e829861551e44c246b6e38a2e8644af85dR1-R23)
* Registered the Snowflake adapter (along with null, MySQL, and PostgreSQL ODBC adapters) with ActiveRecord in `lib/odbc_adapter.rb`.

### Connection Management Refactor

* Refactored connection handling in `ODBCAdapter` and related classes to centralize connection logic in a new `new_client` method, and updated initialization and reconnect logic for better reliability and extensibility. [[1]](diffhunk://#diff-4ad7da319ce42dc938b4eb8b4cb5515148a68215b0a4e1a62962282eb4c73000L26-L38) [[2]](diffhunk://#diff-4ad7da319ce42dc938b4eb8b4cb5515148a68215b0a4e1a62962282eb4c73000R43-R69) [[3]](diffhunk://#diff-4ad7da319ce42dc938b4eb8b4cb5515148a68215b0a4e1a62962282eb4c73000L89-R118)
* Improved error handling and connection usage in query execution, ensuring reconnections on session expiration and using `with_raw_connection` for safer resource management. [[1]](diffhunk://#diff-440de147adf59303e23c25f203cba4cfa81fbc66300abec50b92b4d85c49042bL18-R20) [[2]](diffhunk://#diff-440de147adf59303e23c25f203cba4cfa81fbc66300abec50b92b4d85c49042bL32-R52) [[3]](diffhunk://#diff-440de147adf59303e23c25f203cba4cfa81fbc66300abec50b92b4d85c49042bR61)

### Schema and Quoting Improvements

* Updated table and view listing logic to support Snowflake and handle different driver configurations, and added a `quote_table_name` helper for consistency. [[1]](diffhunk://#diff-e7b49d917c507c9c7d59d92f8b8784283c3794cb1eaceafc15341ad0812f40acL13-R26) [[2]](diffhunk://#diff-e7b49d917c507c9c7d59d92f8b8784283c3794cb1eaceafc15341ad0812f40acR36-R40) [[3]](diffhunk://#diff-7e7f20204ee2a502aab3749ecfc08314eb153faa8370f82844f323f6f8928891R1-R33)
* Ensured proper type casting and bind parameter handling in statement preparation and execution.

### JetBrains IDE Integration

* Added `.idea` configuration files and `.gitignore` entries to support JetBrains IDE (RubyMine, IntelliJ) project setup and version control. [[1]](diffhunk://#diff-21610973868a98feff98dd0460438a8a32cca1447bc8701537ec5048e0c5faebR1-R8) [[2]](diffhunk://#diff-7ea1cd7bd5d16299a0abd33128e8d0a8bc04146f6b00c07bcd3cc0aad813c229R1-R4) [[3]](diffhunk://#diff-0aae258f1732eac2acd4fcdd1af6d0737b4ec8d233136c3ba7c40b6d49aeda50R1-R8) [[4]](diffhunk://#diff-2606f2990241cf00133d5e7041c0765de26aea38465c229484d1f8b10bb92f3fR1-R23) [[5]](diffhunk://#diff-a6dab70bd0e9ffc91d8419ad52225baff3a3e7c9d8e1724f7ed6d96b661d804aR1-R6)

#### PHI

No PHI Changes

## Testing/QA Notes

Let QA Wolf do its thing
Browse around in an environment that has the adapter in use.
Feel free to pull it down and play around. At this point... it should just work. You shouldn't notice any substantial changes between this and the previous adapter version.